### PR TITLE
Fix some typos

### DIFF
--- a/contracts/custody/src/msg.rs
+++ b/contracts/custody/src/msg.rs
@@ -53,7 +53,7 @@ pub enum HandleMsg {
     /// (internal) Swap all coins to stable_denom
     SwapToStableDenom {},
 
-    /// Liquidate colalteral and send liquidated collateral to `to` address
+    /// Liquidate collateral and send liquidated collateral to `to` address
     LiquidateCollateral {
         liquidator: HumanAddr,
         borrower: HumanAddr,
@@ -73,7 +73,7 @@ pub enum HandleMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum Cw20HookMsg {
-    /// Deposit collataerl token
+    /// Deposit collateral token
     DepositCollateral {},
 }
 

--- a/contracts/interest/src/contract.rs
+++ b/contracts/interest/src/contract.rs
@@ -201,7 +201,7 @@ mod tests {
         assert_eq!("0.1", &value.base_rate.to_string());
         assert_eq!("0.1", &value.interest_multiplier.to_string());
 
-        // Unauthorzied err
+        // Unauthorized err
         let env = mock_env("owner0000", &[]);
         let msg = HandleMsg::UpdateConfig {
             owner: None,

--- a/contracts/liquidation/src/msg.rs
+++ b/contracts/liquidation/src/msg.rs
@@ -22,7 +22,7 @@ pub struct InitMsg {
     pub max_premium_rate: Decimal256,
     /// Liquidation threshold amount in stable denom.
     /// When the current collaterals value is smaller than
-    /// the threshold, all callterals will be liquidated
+    /// the threshold, all collaterals will be liquidated
     pub liquidation_threshold: Uint256,
 }
 

--- a/contracts/liquidation/src/testing/tests.rs
+++ b/contracts/liquidation/src/testing/tests.rs
@@ -126,7 +126,7 @@ fn update_config() {
         }
     );
 
-    // Unauthorzied err
+    // Unauthorized err
     let env = mock_env("owner0000", &[]);
     let msg = HandleMsg::UpdateConfig {
         owner: None,

--- a/contracts/market/src/borrow.rs
+++ b/contracts/market/src/borrow.rs
@@ -181,7 +181,7 @@ pub fn compute_interest<S: Storage, A: Api, Q: Querier>(
         &deps.api.human_address(&config.interest_model)?,
         balance,
         state.total_liabilities,
-        state.total_reservess,
+        state.total_reserves,
     )?;
 
     let passed_blocks = block_height - state.last_interest_updated;
@@ -192,7 +192,7 @@ pub fn compute_interest<S: Storage, A: Api, Q: Querier>(
     state.global_interest_index =
         state.global_interest_index * (Decimal256::one() + interest_factor);
     state.total_liabilities += interest_accrued;
-    state.total_reservess += interest_accrued * config.reserve_factor;
+    state.total_reserves += interest_accrued * config.reserve_factor;
     state.last_interest_updated = block_height;
 
     Ok(())

--- a/contracts/market/src/contract.rs
+++ b/contracts/market/src/contract.rs
@@ -39,7 +39,7 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
         &mut deps.storage,
         &State {
             total_liabilities: Decimal256::zero(),
-            total_reservess: Decimal256::zero(),
+            total_reserves: Decimal256::zero(),
             last_interest_updated: env.block.height,
             global_interest_index: Decimal256::one(),
         },

--- a/contracts/market/src/deposit.rs
+++ b/contracts/market/src/deposit.rs
@@ -147,10 +147,10 @@ pub fn compute_exchange_rate_raw(
     contract_balance: Uint256,
 ) -> StdResult<Decimal256> {
     // (anchor_token / stable_denom)
-    // exchange_rate = (balance + total_liabilities - total_reservess) / anchor_token_supply
+    // exchange_rate = (balance + total_liabilities - total_reserves) / anchor_token_supply
     Ok(
         (Decimal256::from_uint256(contract_balance) + state.total_liabilities
-            - state.total_reservess)
+            - state.total_reserves)
             / Decimal256::from_uint256(a_token_supply),
     )
 }

--- a/contracts/market/src/state.rs
+++ b/contracts/market/src/state.rs
@@ -26,7 +26,7 @@ pub struct Config {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct State {
     pub total_liabilities: Decimal256,
-    pub total_reservess: Decimal256,
+    pub total_reserves: Decimal256,
     pub last_interest_updated: u64,
     pub global_interest_index: Decimal256,
 }

--- a/contracts/market/src/testing/borrow_ut.rs
+++ b/contracts/market/src/testing/borrow_ut.rs
@@ -10,7 +10,7 @@ fn proper_compute_loan() {
     let env = mock_env("addr0000", &[]);
     let mock_state = State {
         total_liabilities: Decimal256::from_uint256(1000000u128),
-        total_reservess: Decimal256::from_uint256(0u128),
+        total_reserves: Decimal256::from_uint256(0u128),
         last_interest_updated: env.block.height,
         global_interest_index: Decimal256::one(),
     };
@@ -27,7 +27,7 @@ fn proper_compute_loan() {
 
     let mock_state2 = State {
         total_liabilities: Decimal256::from_uint256(300000u128),
-        total_reservess: Decimal256::from_uint256(1000u128),
+        total_reserves: Decimal256::from_uint256(1000u128),
         last_interest_updated: env.block.height,
         global_interest_index: Decimal256::from_uint256(2u128),
     };
@@ -85,7 +85,7 @@ fn proper_compute_interest() {
 
     let mut mock_state = State {
         total_liabilities: Decimal256::from_uint256(1000000u128),
-        total_reservess: Decimal256::zero(),
+        total_reserves: Decimal256::zero(),
         last_interest_updated: env.block.height,
         global_interest_index: Decimal256::one(),
     };
@@ -106,7 +106,7 @@ fn proper_compute_interest() {
         State {
             global_interest_index: Decimal256::from_uint256(1u128),
             total_liabilities: Decimal256::from_uint256(1000000u128),
-            total_reservess: Decimal256::zero(),
+            total_reserves: Decimal256::zero(),
             last_interest_updated: env.block.height,
         }
     );
@@ -126,7 +126,7 @@ fn proper_compute_interest() {
         State {
             global_interest_index: Decimal256::from_uint256(2u128),
             total_liabilities: Decimal256::from_uint256(2000000u128),
-            total_reservess: Decimal256::from_uint256(3000u128),
+            total_reserves: Decimal256::from_uint256(3000u128),
             last_interest_updated: env.block.height,
         }
     );

--- a/contracts/market/src/testing/deposit_ut.rs
+++ b/contracts/market/src/testing/deposit_ut.rs
@@ -49,7 +49,7 @@ fn proper_compute_exchange_rate() {
     )]);
     let mock_state = State {
         total_liabilities: Decimal256::from_uint256(50000u128),
-        total_reservess: Decimal256::from_uint256(550000u128),
+        total_reserves: Decimal256::from_uint256(550000u128),
         last_interest_updated: env.block.height,
         global_interest_index: Decimal256::one(),
     };

--- a/contracts/market/src/testing/tests.rs
+++ b/contracts/market/src/testing/tests.rs
@@ -92,7 +92,7 @@ fn proper_initialization() {
     let query_res = query(&deps, QueryMsg::State {}).unwrap();
     let state: State = from_binary(&query_res).unwrap();
     assert_eq!(Decimal256::zero(), state.total_liabilities);
-    assert_eq!(Decimal256::zero(), state.total_reservess);
+    assert_eq!(Decimal256::zero(), state.total_reserves);
     assert_eq!(env.block.height, state.last_interest_updated);
     assert_eq!(Decimal256::one(), state.global_interest_index);
 }
@@ -159,7 +159,7 @@ fn update_config() {
     assert_eq!(Decimal256::percent(1), config_res.reserve_factor);
     assert_eq!(HumanAddr::from("interest2"), config_res.interest_model);
 
-    // Unauthorzied err
+    // Unauthorized err
     let env = mock_env("owner", &[]);
     let msg = HandleMsg::UpdateConfig {
         owner_addr: None,
@@ -392,7 +392,7 @@ fn deposit_stable() {
         State {
             global_interest_index: Decimal256::from_uint256(1u128),
             total_liabilities: Decimal256::zero(),
-            total_reservess: Decimal256::zero(),
+            total_reserves: Decimal256::zero(),
             last_interest_updated: env.block.height,
         }
     );
@@ -425,7 +425,7 @@ fn deposit_stable() {
         &mut deps.storage,
         &State {
             total_liabilities: Decimal256::from_uint256(50000u128),
-            total_reservess: Decimal256::from_uint256(550000u128),
+            total_reserves: Decimal256::from_uint256(550000u128),
             last_interest_updated: env.block.height,
             global_interest_index: Decimal256::one(),
         },
@@ -477,7 +477,7 @@ fn deposit_stable() {
         &mut deps.storage,
         &State {
             total_liabilities: Decimal256::from_uint256(50000u128),
-            total_reservess: Decimal256::from_uint256(550000u128),
+            total_reserves: Decimal256::from_uint256(550000u128),
             last_interest_updated: env.block.height,
             global_interest_index: Decimal256::one(),
         },
@@ -505,7 +505,7 @@ fn deposit_stable() {
         State {
             global_interest_index: Decimal256::from_uint256(2u128),
             total_liabilities: Decimal256::from_uint256(100000u128),
-            total_reservess: Decimal256::from_uint256(550150u128),
+            total_reserves: Decimal256::from_uint256(550150u128),
             last_interest_updated: env.block.height,
         }
     );
@@ -621,7 +621,7 @@ fn redeem_stable() {
         &mut deps.storage,
         &State {
             total_liabilities: Decimal256::from_uint256(2000000u128),
-            total_reservess: Decimal256::from_uint256(1500000u128),
+            total_reserves: Decimal256::from_uint256(1500000u128),
             last_interest_updated: env.block.height,
             global_interest_index: Decimal256::one(),
         },
@@ -721,7 +721,7 @@ fn borrow_stable() {
         &mut deps.storage,
         &State {
             total_liabilities: Decimal256::from_uint256(1000000u128),
-            total_reservess: Decimal256::zero(),
+            total_reserves: Decimal256::zero(),
             last_interest_updated: env.block.height,
             global_interest_index: Decimal256::one(),
         },
@@ -740,7 +740,7 @@ fn borrow_stable() {
     // interest_accrued = 1000000
     // global_interest_index = 2
     // total_liabilities = 2500000
-    // total_reservess = 3000
+    // total_reserves = 3000
     // last_interest_updated = 100
     assert_eq!(
         res.log,
@@ -773,7 +773,7 @@ fn borrow_stable() {
         state,
         State {
             total_liabilities: Decimal256::from_uint256(2500000u128),
-            total_reservess: Decimal256::from_uint256(3000u128),
+            total_reserves: Decimal256::from_uint256(3000u128),
             last_interest_updated: env.block.height,
             global_interest_index: Decimal256::from_uint256(2u128),
         }
@@ -894,7 +894,7 @@ fn repay_stable() {
         &mut deps.storage,
         &State {
             total_liabilities: Decimal256::from_uint256(1000000u128),
-            total_reservess: Decimal256::zero(),
+            total_reserves: Decimal256::zero(),
             last_interest_updated: env.block.height,
             global_interest_index: Decimal256::one(),
         },
@@ -1042,7 +1042,7 @@ fn repay_stable_from_liquidation() {
         &mut deps.storage,
         &State {
             total_liabilities: Decimal256::from_uint256(1000000u128),
-            total_reservess: Decimal256::zero(),
+            total_reserves: Decimal256::zero(),
             last_interest_updated: env.block.height,
             global_interest_index: Decimal256::one(),
         },

--- a/contracts/oracle/src/contract.rs
+++ b/contracts/oracle/src/contract.rs
@@ -212,7 +212,7 @@ mod tests {
         assert_eq!("owner0001", value.owner.as_str());
         assert_eq!("base0000", &value.base_asset.to_string());
 
-        // Unauthorzied err
+        // Unauthorized err
         let env = mock_env("owner0000", &[]);
         let msg = HandleMsg::UpdateConfig { owner: None };
 
@@ -284,7 +284,7 @@ mod tests {
             }
         );
 
-        // Unautorized try
+        // Unauthorized try
         let env = mock_env("addr0001", &[]);
         let msg = HandleMsg::FeedPrice {
             prices: vec![("mAPPL".to_string(), Decimal256::from_str("1.2").unwrap())],

--- a/contracts/overseer/src/collateral.rs
+++ b/contracts/overseer/src/collateral.rs
@@ -42,7 +42,7 @@ pub fn lock_collateral<S: Storage, A: Api, Q: Querier>(
         }));
     }
 
-    // Loging stuff, so can be removed
+    // Logging stuff, so can be removed
     let collateral_logs: Vec<String> = collaterals_human
         .iter()
         .map(|c| format!("{}{}", c.1, c.0.to_string()))
@@ -102,7 +102,7 @@ pub fn unlock_collateral<S: Storage, A: Api, Q: Querier>(
         }));
     }
 
-    // Loging stuff, so can be removed
+    // Logging stuff, so can be removed
     let collateral_logs: Vec<String> = collaterals_human
         .iter()
         .map(|c| format!("{}{}", c.1, c.0.to_string()))

--- a/contracts/overseer/src/msg.rs
+++ b/contracts/overseer/src/msg.rs
@@ -14,7 +14,7 @@ pub struct InitMsg {
     pub oracle_contract: HumanAddr,
     /// Market contract address to receive missing interest buffer
     pub market_contract: HumanAddr,
-    /// Liquidation model contract address to compute liqudation amount
+    /// Liquidation model contract address to compute liquidation amount
     pub liquidation_model: HumanAddr,
     /// The base denomination used when fetching oracle price,
     /// reward distribution, and borrow

--- a/contracts/overseer/src/testing/tests.rs
+++ b/contracts/overseer/src/testing/tests.rs
@@ -125,7 +125,7 @@ fn update_config() {
     assert_eq!(Decimal256::percent(10), config_res.buffer_distribution_rate);
     assert_eq!(100000u64, config_res.epoch_period);
 
-    // Unauthorzied err
+    // Unauthorized err
     let env = mock_env("owner", &[]);
     let msg = HandleMsg::UpdateConfig {
         owner_addr: None,


### PR DESCRIPTION
Attempted to fix "total_reserves" in market's State, and some other typos in comments.