### PR TITLE
[Feature]: Revert the new tax estimation

### DIFF
--- a/contracts/custody_beth/src/testing/tests.rs
+++ b/contracts/custody_beth/src/testing/tests.rs
@@ -684,7 +684,7 @@ fn distribute_hook() {
             to_address: "overseer".to_string(),
             amount: vec![Coin {
                 denom: "uusd".to_string(),
-                amount: Uint128::from(990099u128)
+                amount: Uint128::from(990100u128)
             }],
         })),],
     )

--- a/contracts/custody_bluna/src/testing/tests.rs
+++ b/contracts/custody_bluna/src/testing/tests.rs
@@ -685,7 +685,7 @@ fn distribute_hook() {
             to_address: "overseer".to_string(),
             amount: vec![Coin {
                 denom: "uusd".to_string(),
-                amount: Uint128::from(990099u128)
+                amount: Uint128::from(990100u128)
             }],
         })),],
     )

--- a/contracts/liquidation/src/testing/tests.rs
+++ b/contracts/liquidation/src/testing/tests.rs
@@ -398,14 +398,14 @@ fn execute_bid() {
                 to_address: "repay0000".to_string(),
                 amount: vec![Coin {
                     denom: "uusd".to_string(),
-                    amount: Uint128::from(485198u128), // 490050 / (1 + tax_rate)
+                    amount: Uint128::from(485199u128), // 490050 / (1 + tax_rate)
                 }]
             })),
             SubMsg::new(CosmosMsg::Bank(BankMsg::Send {
                 to_address: "fee0000".to_string(),
                 amount: vec![Coin {
                     denom: "uusd".to_string(),
-                    amount: Uint128::from(4900u128), // 4950 / (1 + tax_rate)
+                    amount: Uint128::from(4901u128), // 4950 / (1 + tax_rate)
                 }]
             })),
         ]
@@ -438,14 +438,14 @@ fn execute_bid() {
                 to_address: "addr0001".to_string(),
                 amount: vec![Coin {
                     denom: "uusd".to_string(),
-                    amount: Uint128::from(485198u128), // 490050 / (1 + tax_rate)
+                    amount: Uint128::from(485199u128), // 490050 / (1 + tax_rate)
                 }]
             })),
             SubMsg::new(CosmosMsg::Bank(BankMsg::Send {
                 to_address: "addr0001".to_string(),
                 amount: vec![Coin {
                     denom: "uusd".to_string(),
-                    amount: Uint128::from(4900u128), // 4950 / (1 + tax_rate)
+                    amount: Uint128::from(4901u128), // 4950 / (1 + tax_rate)
                 }]
             })),
         ]

--- a/contracts/market/src/testing/tests.rs
+++ b/contracts/market/src/testing/tests.rs
@@ -1781,7 +1781,7 @@ fn execute_epoch_operations() {
             to_address: "collector".to_string(),
             amount: vec![Coin {
                 denom: "uusd".to_string(),
-                amount: Uint128::from(2970u128), // 1% tax
+                amount: Uint128::from(2971u128), // 1% tax
             }],
         }))]
     );

--- a/contracts/overseer/src/testing/tests.rs
+++ b/contracts/overseer/src/testing/tests.rs
@@ -529,7 +529,7 @@ fn execute_epoch_operations() {
                 funds: vec![],
                 msg: to_binary(&ExecuteMsg::UpdateEpochState {
                     interest_buffer: Uint256::from(9999746320u128),
-                    distributed_interest: Uint256::from(53148u128),
+                    distributed_interest: Uint256::from(53149u128),
                 })
                 .unwrap(),
             }))
@@ -543,7 +543,7 @@ fn execute_epoch_operations() {
             attr("deposit_rate", "0.000000482253086419"),
             attr("exchange_rate", "1.25"),
             attr("aterra_supply", "1000000"),
-            attr("distributed_interest", "53148"),
+            attr("distributed_interest", "53149"),
             attr("anc_purchase_amount", "200000")
         ]
     );

--- a/packages/moneymarket/src/querier.rs
+++ b/packages/moneymarket/src/querier.rs
@@ -74,7 +74,7 @@ pub fn compute_tax(deps: Deps, coin: &Coin) -> StdResult<Uint256> {
     let tax_cap = Uint256::from((terra_querier.query_tax_cap(coin.denom.to_string())?).cap);
     let amount = Uint256::from(coin.amount);
     Ok(std::cmp::min(
-        amount * Decimal256::one() - amount / (Decimal256::one() + tax_rate),
+        amount * (Decimal256::one() - Decimal256::one() / (Decimal256::one() + tax_rate)),
         tax_cap,
     ))
 }

--- a/packages/moneymarket/src/testing.rs
+++ b/packages/moneymarket/src/testing.rs
@@ -35,7 +35,7 @@ fn test_compute_tax() {
     // normal tax
     assert_eq!(
         compute_tax(deps.as_ref(), &Coin::new(50000000u128, "uusd")).unwrap(),
-        Uint256::from(495050u64)
+        Uint256::from(495049u64)
     );
 }
 
@@ -62,7 +62,7 @@ fn test_deduct_tax() {
         deduct_tax(deps.as_ref(), Coin::new(50000000u128, "uusd")).unwrap(),
         Coin {
             denom: "uusd".to_string(),
-            amount: Uint128::from(49504950u128)
+            amount: Uint128::from(49504951u128)
         }
     );
 }


### PR DESCRIPTION
Tax estimation needed integration tests and it is not a good practice to release it without integration tests. In addition, we need contracts to be compatible with the running contract on the mainnet for Columbus-5 migration. We will fix the issue with the next version of the code.