### PR TITLE
fix: comments, add_message instead of submsg, smart query

### DIFF
--- a/contracts/custody_beth/Cargo.toml
+++ b/contracts/custody_beth/Cargo.toml
@@ -38,7 +38,7 @@ moneymarket = { path = "../../packages/moneymarket", default-features = false, v
 cw20 = "0.8"
 terra-cosmwasm = "2.2.0"
 cosmwasm-bignumber = "2.2.0"
-cosmwasm-std = { version = "0.16.0", features = ["iterator"] }
+cosmwasm-std = "0.16.0"
 cosmwasm-storage = { version = "0.16.0", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/custody_beth/src/distribution.rs
+++ b/contracts/custody_beth/src/distribution.rs
@@ -11,9 +11,9 @@ use crate::state::{read_config, BETHAccruedRewardsResponse, Config};
 use moneymarket::querier::{deduct_tax, query_all_balances, query_balance};
 use terra_cosmwasm::{create_swap_msg, TerraMsgWrapper};
 
-// REWARD_THRESHOLD is there to make sure that
-// if there is some reward and it is not above 1 UST
-// do not send the ClaimRewards
+// REWARD_THRESHOLD
+// This value is used as the minimum reward claim amount
+// thus if a user's reward is less than 1 ust do not send the ClaimRewards msg
 const REWARDS_THRESHOLD: Uint128 = Uint128::new(1000000);
 
 /// Request withdraw reward operation to

--- a/contracts/custody_bluna/Cargo.toml
+++ b/contracts/custody_bluna/Cargo.toml
@@ -38,7 +38,7 @@ moneymarket = { path = "../../packages/moneymarket", default-features = false, v
 cw20 = { version = "0.8.0" }
 terra-cosmwasm = "2.2.0"
 cosmwasm-bignumber = "2.2.0"
-cosmwasm-std = { version = "0.16.0", features = ["iterator"] }
+cosmwasm-std = "0.16.0"
 cosmwasm-storage = { version = "0.16.0", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/custody_bluna/src/collateral.rs
+++ b/contracts/custody_bluna/src/collateral.rs
@@ -6,7 +6,7 @@ use crate::state::{
 use cosmwasm_bignumber::Uint256;
 use cosmwasm_std::{
     attr, to_binary, Addr, CanonicalAddr, CosmosMsg, Deps, DepsMut, MessageInfo, Response,
-    StdError, StdResult, SubMsg, WasmMsg,
+    StdError, StdResult, WasmMsg,
 };
 use cw20::Cw20ExecuteMsg;
 use moneymarket::custody::{BorrowerResponse, BorrowersResponse};
@@ -23,7 +23,7 @@ pub fn deposit_collateral(
     let borrower_raw = deps.api.addr_canonicalize(borrower.as_str())?;
     let mut borrower_info: BorrowerInfo = read_borrower_info(deps.storage, &borrower_raw);
 
-    // withdraw rewards to pending rewards
+    // increase borrower collateral
     borrower_info.balance += amount;
     borrower_info.spendable += amount;
 
@@ -58,7 +58,7 @@ pub fn withdraw_collateral(
         )));
     }
 
-    // withdraw rewards to pending rewards
+    // decrease borrower collateral
     borrower_info.balance = borrower_info.balance - amount;
     borrower_info.spendable = borrower_info.spendable - amount;
 
@@ -69,7 +69,7 @@ pub fn withdraw_collateral(
     }
 
     Ok(Response::new()
-        .add_submessages(vec![SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
+        .add_message(CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: deps
                 .api
                 .addr_humanize(&config.collateral_token)?
@@ -79,7 +79,7 @@ pub fn withdraw_collateral(
                 recipient: borrower.to_string(),
                 amount: amount.into(),
             })?,
-        }))])
+        }))
         .add_attributes(vec![
             attr("action", "withdraw_collateral"),
             attr("borrower", borrower.as_str()),
@@ -179,7 +179,7 @@ pub fn liquidate_collateral(
     store_borrower_info(deps.storage, &borrower_raw, &borrower_info)?;
 
     Ok(Response::new()
-        .add_submessages(vec![SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
+        .add_message(CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: deps
                 .api
                 .addr_humanize(&config.collateral_token)?
@@ -203,7 +203,7 @@ pub fn liquidate_collateral(
                     ),
                 })?,
             })?,
-        }))])
+        }))
         .add_attributes(vec![
             attr("action", "liquidate_collateral"),
             attr("liquidator", liquidator),

--- a/contracts/liquidation/Cargo.toml
+++ b/contracts/liquidation/Cargo.toml
@@ -36,7 +36,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 [dependencies]
 cw20 = { version = "0.8.0" }
 moneymarket = { path = "../../packages/moneymarket", default-features = false, version = "0.2.0"}
-cosmwasm-std = { version = "0.16.0", features = ["iterator"] }
+cosmwasm-std = "0.16.0"
 cosmwasm-storage = { version = "0.16.0", features = ["iterator"] }
 cosmwasm-bignumber = "2.2.0"
 schemars = "0.8.1"

--- a/contracts/market/Cargo.toml
+++ b/contracts/market/Cargo.toml
@@ -40,7 +40,7 @@ cw20 = { version = "0.8.0" }
 protobuf = { version = "2", features = ["with-bytes"] }
 terraswap = { version = "2.3.0" }
 cosmwasm-bignumber = "2.2.0"
-cosmwasm-std = { version = "0.16.0", features = ["iterator"] }
+cosmwasm-std = "0.16.0"
 cosmwasm-storage = { version = "0.16.0", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/market/src/contract.rs
+++ b/contracts/market/src/contract.rs
@@ -374,10 +374,10 @@ pub fn execute_epoch_operations(
     // Update total_reserves and send it to collector contract
     // only when there is enough balance
     let total_reserves = state.total_reserves * Uint256::one();
-    let messages: Vec<SubMsg> = if !total_reserves.is_zero() && balance > total_reserves {
+    let messages: Vec<CosmosMsg> = if !total_reserves.is_zero() && balance > total_reserves {
         state.total_reserves = state.total_reserves - Decimal256::from_uint256(total_reserves);
 
-        vec![SubMsg::new(CosmosMsg::Bank(BankMsg::Send {
+        vec![CosmosMsg::Bank(BankMsg::Send {
             to_address: deps
                 .api
                 .addr_humanize(&config.collector_contract)?
@@ -389,7 +389,7 @@ pub fn execute_epoch_operations(
                     amount: total_reserves.into(),
                 },
             )?],
-        }))]
+        })]
     } else {
         vec![]
     };
@@ -407,13 +407,11 @@ pub fn execute_epoch_operations(
 
     store_state(deps.storage, &state)?;
 
-    Ok(Response::new()
-        .add_submessages(messages)
-        .add_attributes(vec![
-            attr("action", "execute_epoch_operations"),
-            attr("total_reserves", total_reserves),
-            attr("anc_emission_rate", state.anc_emission_rate.to_string()),
-        ]))
+    Ok(Response::new().add_messages(messages).add_attributes(vec![
+        attr("action", "execute_epoch_operations"),
+        attr("total_reserves", total_reserves),
+        attr("anc_emission_rate", state.anc_emission_rate.to_string()),
+    ]))
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/oracle/Cargo.toml
+++ b/contracts/oracle/Cargo.toml
@@ -36,7 +36,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 [dependencies]
 moneymarket = { path = "../../packages/moneymarket", default-features = false, version = "0.2.0"}
 cosmwasm-bignumber = "2.2.0"
-cosmwasm-std = { version = "0.16.0", features = ["iterator"] }
+cosmwasm-std = "0.16.0"
 cosmwasm-storage = { version = "0.16.0", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/overseer/Cargo.toml
+++ b/contracts/overseer/Cargo.toml
@@ -36,7 +36,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 [dependencies]
 moneymarket = { path = "../../packages/moneymarket", default-features = false, version = "0.2.0"}
 cosmwasm-bignumber = "2.2.0"
-cosmwasm-std = { version = "0.16.0", features = ["iterator"] }
+cosmwasm-std = "0.16.0"
 cosmwasm-storage = { version = "0.16.0", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/overseer/src/collateral.rs
+++ b/contracts/overseer/src/collateral.rs
@@ -31,10 +31,10 @@ pub fn lock_collateral(
     cur_collaterals.add(collaterals.clone());
     store_collaterals(deps.storage, &borrower_raw, &cur_collaterals)?;
 
-    let mut messages: Vec<SubMsg> = vec![];
+    let mut messages: Vec<CosmosMsg> = vec![];
     for collateral in collaterals {
         let whitelist_elem: WhitelistElem = read_whitelist_elem(deps.storage, &collateral.0)?;
-        messages.push(SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
+        messages.push(CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: deps
                 .api
                 .addr_humanize(&whitelist_elem.custody_contract)?
@@ -44,7 +44,7 @@ pub fn lock_collateral(
                 borrower: info.sender.to_string(),
                 amount: collateral.1,
             })?,
-        })));
+        }));
     }
 
     // Logging stuff, so can be removed
@@ -53,13 +53,11 @@ pub fn lock_collateral(
         .map(|c| format!("{}{}", c.1, c.0.to_string()))
         .collect();
 
-    Ok(Response::new()
-        .add_submessages(messages)
-        .add_attributes(vec![
-            attr("action", "lock_collateral"),
-            attr("borrower", info.sender),
-            attr("collaterals", collateral_logs.join(",")),
-        ]))
+    Ok(Response::new().add_messages(messages).add_attributes(vec![
+        attr("action", "lock_collateral"),
+        attr("borrower", info.sender),
+        attr("collaterals", collateral_logs.join(",")),
+    ]))
 }
 
 pub fn unlock_collateral(
@@ -180,12 +178,12 @@ pub fn liquidate_collateral(
     let prev_balance: Uint256 =
         query_balance(deps.as_ref(), market_contract.clone(), config.stable_denom)?;
 
-    let liquidation_messages: Vec<SubMsg> = liquidation_amount
+    let liquidation_messages: Vec<CosmosMsg> = liquidation_amount
         .iter()
         .map(|collateral| {
             let whitelist_elem: WhitelistElem = read_whitelist_elem(deps.storage, &collateral.0)?;
 
-            Ok(SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
+            Ok(CosmosMsg::Wasm(WasmMsg::Execute {
                 contract_addr: deps
                     .api
                     .addr_humanize(&whitelist_elem.custody_contract)?
@@ -196,25 +194,21 @@ pub fn liquidate_collateral(
                     borrower: borrower.to_string(),
                     amount: collateral.1,
                 })?,
-            })))
+            }))
         })
         .filter(|msg| msg.is_ok())
-        .collect::<StdResult<Vec<SubMsg>>>()?;
+        .collect::<StdResult<Vec<CosmosMsg>>>()?;
 
-    Ok(Response::new().add_submessages(
-        vec![
-            liquidation_messages,
-            vec![SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
-                contract_addr: market_contract.to_string(),
-                funds: vec![],
-                msg: to_binary(&MarketExecuteMsg::RepayStableFromLiquidation {
-                    borrower: borrower.to_string(),
-                    prev_balance,
-                })?,
-            }))],
-        ]
-        .concat(),
-    ))
+    Ok(Response::new()
+        .add_messages(liquidation_messages)
+        .add_message(CosmosMsg::Wasm(WasmMsg::Execute {
+            contract_addr: market_contract.to_string(),
+            funds: vec![],
+            msg: to_binary(&MarketExecuteMsg::RepayStableFromLiquidation {
+                borrower: borrower.to_string(),
+                prev_balance,
+            })?,
+        })))
 }
 
 pub fn query_collaterals(deps: Deps, borrower: Addr) -> StdResult<CollateralsResponse> {


### PR DESCRIPTION
- Fix Yun's requested changes here: https://github.com/Anchor-Protocol/money-market-contracts/pull/41
- Change SubMsg::new to regular CosmosMsg for readability
- fix comments
- smart query for Token Contract queries 