### PR TITLE
Update broken readme links 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Anchor Money Market Contracts
 A Rust and [CosmWasm](https://cosmwasm.com/) implementation of the Anchor Protocol money market on the [Terra blockchain](https://terra.money).
 
-You can find information about the architecture, usage, and function of the smart contracts in the [documentation](https://app.gitbook.com/@anchor-protocol/s/anchor-2/smart-contracts/money-market).
+You can find information about the architecture, usage, and function of the smart contracts in the [documentation](https://docs.anchorprotocol.com/).
 
 ### Dependencies
 
@@ -11,15 +11,16 @@ Money Market has dependencies on [Anchor Token Contracts](https://github.com/anc
 
 ## Contracts
 
-| Contract                                               | Reference                                                                                                      | Description                                                                   |
-| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| [`overseer`](./contracts/overseer)                     | [doc](https://app.gitbook.com/@anchor-protocol/s/anchor-2/smart-contracts/money-market/overseer)               | Manages money market overalls, stores borrower information                    |
-| [`market`](../contracts/market)                        | [doc](https://app.gitbook.com/@anchor-protocol/s/anchor-2/smart-contracts/money-market/market)                 | Handles Terra stablecoin deposits and borrows, ANC distribution to borrowers  |
-| [`custody_bluna`](./contracts/custody_bluna)           | [doc](https://app.gitbook.com/@anchor-protocol/s/anchor-2/smart-contracts/money-market/custody-bluna-specific) | Handles bLuna collateral deposits and withdrawals                             |
-| [`interest_model`](./contracts/interest_model)         | [doc](https://app.gitbook.com/@anchor-protocol/s/anchor-2/smart-contracts/money-market/interest_model)         | Calculates the current borrow interest rate based on the market situation     |
-| [`distribution_model`](./contracts/distribution_model) | [doc](https://app.gitbook.com/@anchor-protocol/s/anchor-2/smart-contracts/money-market/distribution_model)     | Calculates the borrower ANC emission rate based on the previous emission rate |
-| [`oracle`](./contracts/oracle)                         | [doc](https://app.gitbook.com/@anchor-protocol/s/anchor-2/smart-contracts/money-market/oracle)                 | Provides a price feed for bAsset collaterals                                  |
-| [`liquidation`](./contracts/liquidation)               | [doc](https://app.gitbook.com/@anchor-protocol/s/anchor-2/smart-contracts/liquidations/liquidation-contract)   | OTC exchange contract for bAsset collateral liquidations                      |
+| Contract                                               | Reference                                                                                  | Description                                                                   |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| [`overseer`](./contracts/overseer)                     | [doc](https://docs.anchorprotocol.com/smart-contracts/money-market/overseer)               | Manages money market overalls, stores borrower information                    |
+| [`market`](../contracts/market)                        | [doc](https://docs.anchorprotocol.com/smart-contracts/money-market/market)                 | Handles Terra stablecoin deposits and borrows, ANC distribution to borrowers  |
+| [`custody_bluna`](./contracts/custody_bluna)           | [doc](https://docs.anchorprotocol.com/smart-contracts/money-market/custody-bluna-specific) | Handles bLuna collateral deposits and withdrawals                             |
+| [`custody_beth`](./contracts/custody_beth)             | [doc](https://docs.anchorprotocol.com/smart-contracts/money-market/custody-beth)           | Handles bEth collateral deposits and withdrawals                              |
+| [`interest_model`](./contracts/interest_model)         | [doc](https://docs.anchorprotocol.com/smart-contracts/money-market/interest-model)         | Calculates the current borrow interest rate based on the market situation     |
+| [`distribution_model`](./contracts/distribution_model) | [doc](https://docs.anchorprotocol.com/smart-contracts/money-market/distribution-model)     | Calculates the borrower ANC emission rate based on the previous emission rate |
+| [`oracle`](./contracts/oracle)                         | [doc](https://docs.anchorprotocol.com/smart-contracts/money-market/oracle)                 | Provides a price feed for bAsset collaterals                                  |
+| [`liquidation`](./contracts/liquidation)               | [doc](https://docs.anchorprotocol.com/smart-contracts/liquidations)                        | OTC exchange contract for bAsset collateral liquidations                      |
 
 ## Development
 
@@ -38,7 +39,7 @@ rustup default stable
 rustup target add wasm32-unknown-unknown
 ```
 
-3. Make sure [Docker](https://www.docker.com/) is installed
+3. Make sure [Docker](https://www.docker.com/) is installed.
 
 ### Unit / Integration Tests
 

--- a/contracts/custody_beth/README.md
+++ b/contracts/custody_beth/README.md
@@ -1,7 +1,7 @@
 # Custody bEth
 
-**NOTE**: Reference documentation for this contract is available [here](https://app.gitbook.com/@anchor-protocol/s/anchor-2/smart-contracts/money-market/custody-beth-specific).
+**NOTE**: Reference documentation for this contract is available [here](https://docs.anchorprotocol.com/smart-contracts/money-market/custody-beth).
 
-The Custody contract is where supplied bAsset collaterals are managed. Users can make collateral 
-deposits and withdrawals to and from this contract. The Custody contract is also responsible for 
-claiming bAsset rewards and converting them to Terra stable coins, which is then sent to the [Overseer contract](../overseer) for eventual distribution.
+The Custody contract is where supplied bAsset collaterals are managed. Users can make collateral
+deposits and withdrawals to and from this contract. The Custody contract is also responsible for
+claiming bAsset rewards and converting them to Terra stable coins, which are then sent to the [Overseer contract](../overseer) for eventual distribution.

--- a/contracts/custody_bluna/README.md
+++ b/contracts/custody_bluna/README.md
@@ -1,7 +1,7 @@
 # Custody bLuna
 
-**NOTE**: Reference documentation for this contract is available [here](https://app.gitbook.com/@anchor-protocol/s/anchor-2/smart-contracts/money-market/custody-bluna-specific).
+**NOTE**: Reference documentation for this contract is available [here](https://docs.anchorprotocol.com/smart-contracts/money-market/custody-bluna-specific).
 
-The Custody contract is where supplied bAsset collaterals are managed. Users can make collateral 
-deposits and withdrawals to and from this contract. The Custody contract is also responsible for 
-claiming bAsset rewards and converting them to Terra stable coins, which is then sent to the [Overseer contract](../overseer) for eventual distribution.
+The Custody contract is where supplied bAsset collaterals are managed. Users can make collateral
+deposits and withdrawals to and from this contract. The Custody contract is also responsible for
+claiming bAsset rewards and converting them to Terra stable coins, which are then sent to the [Overseer contract](../overseer) for eventual distribution.

--- a/contracts/distribution_model/README.md
+++ b/contracts/distribution_model/README.md
@@ -1,10 +1,10 @@
 # Distribution Model
 
-**NOTE**: Reference documentation for this contract is available [here](https://app.gitbook.com/@anchor-protocol/s/anchor-2/smart-contracts/money-market/distribution-model).
+**NOTE**: Reference documentation for this contract is available [here](https://docs.anchorprotocol.com/smart-contracts/money-market/distribution-model).
 
 
-The Distribution Model contract manages the calculation of the ANC emission rate, 
-using fed in deposit rate information. At the time of protocol genesis, the 
-emission rate adjusts to double when the deposit rate is below the targeted rate 
-and decreases by 10% if the deposit rate is above the targeted rate. Further 
-descriptions on the ANC emission rate control mechanism can be found here.
+The Distribution Model contract manages the calculation of the ANC emission rate,
+using fed-in deposit rate information. At the time of protocol genesis, the 
+emission rate adjusts to double when the deposit rate is below the targeted rate
+and decreases by 10% if the deposit rate is above the targeted rate. Further
+descriptions on the ANC emission rate control mechanism can be found [here](https://docs.anchorprotocol.com/protocol/anchor-token-anc#anchor-token-supply).

--- a/contracts/interest_model/README.md
+++ b/contracts/interest_model/README.md
@@ -1,8 +1,8 @@
 # Interest Model
 
-**NOTE**: Reference documentation for this contract is available [here](https://app.gitbook.com/@anchor-protocol/s/anchor-2/smart-contracts/money-market/interest-model).
+**NOTE**: Reference documentation for this contract is available [here](https://docs.anchorprotocol.com/smart-contracts/money-market/interest-model).
 
-The Interest Model contract is responsible for calculating the current borrow 
-interest rate for stablecoin loans, based on the fed in market details. The 
-interest rate is initially set to increase proportionally with market utilization, 
+The Interest Model contract is responsible for calculating the current borrow
+interest rate for stablecoin loans, based on the fed in market details. The
+interest rate is initially set to increase proportionally with market utilization,
 or the stablecoin borrow demand of the Anchor Money Market.

--- a/contracts/liquidation/README.md
+++ b/contracts/liquidation/README.md
@@ -1,22 +1,22 @@
 # Liquidation
 
-**NOTE**: Reference documentation for this contract is available [here](https://app.gitbook.com/@anchor-protocol/s/anchor-2/smart-contracts/liquidations/liquidation-contract).
+**NOTE**: Reference documentation for this contract is available [here](https://docs.anchorprotocol.com/smart-contracts/liquidations).
 
-The Liquidation Contract enable users to submit Terra stablecoin bids for 
-a Cw20-compliant token. Bidders can specify the rate of premium they will 
-receive on bid execution, and the maximum premium rate is set at 20%.
+The Liquidation Contract enable users to submit Terra stablecoin bids for
+a Cw20-compliant token. Bidders can specify the rate of premium they will
+receive on bid execution. The maximum premium rate is set at 20%.
 
-Upon execution of a bid, Cw20 tokens are sent to the bidder, while the 
-bidder's Terra stablecoins are sent to the repay address (if not specified, 
-sent to message sender). The oracle contract is responsible for providing 
+Upon execution of a bid, the Cw20 tokens are sent to the bidder. The
+bidder's Terra stablecoins are sent to the repay address. If a repay address is not specified,
+the Terra stablecoins are sent sent to the message sender. The Oracle contract is responsible for providing
 the relevant Cw20 token prices.
 
-Additionally, the Liquidation Contract serves as the point of calculation 
-for partial collateral liquidations, where a loan position is liquidated 
-until it reaches a safe `borrow_amount / borrow_limit` ratio. The required 
-liquidation amount for each collateral is calculated based on the fed-in 
+Additionally, the Liquidation contract serves as the point of calculation
+for partial collateral liquidations where a loan position is liquidated
+until it reaches a safe `borrow_amount / borrow_limit` ratio. The required
+liquidation amount for each collateral is calculated based on the fed-in
 loan position's attributes.
 
-Price data from the Oracle contract are only valid for 60 seconds 
-`price_timeframe`. The Liquidation contract disables bid executions until 
-new price data is fed-in to the Oracle contract.
+Price data from the Oracle contract are only valid for 60 seconds
+`price_timeframe`. The Liquidation contract disables bid executions until
+new price data is fed into the Oracle contract.

--- a/contracts/liquidation_queue/README.md
+++ b/contracts/liquidation_queue/README.md
@@ -1,1 +1,9 @@
 # Liquidation Queue
+
+**NOTE**: Reference documentation for this contract is available [here](https://docs.anchorprotocol.com/smart-contracts/liquidations/liquidation-queue-contract).
+
+The Liquidation contract enables users to submit Terra stablecoin bids for a Cw20-compliant token. Bidders can submit a bid to one of the bid pools; each of the pools deposited funds are used to buy the liquidated collateral at different discount rates. There are 31 slots per collateral, from 0% to 30%; users can bid on one or more slots.
+Upon execution of a bid, Cw20 tokens are sent to the bidder, while the bidder's Terra stablecoins are sent to the repay address (if not specified, sent to message sender). A portion of the collateral value liquidated will be given to the address triggering the liquidation (liquidator_fee).
+
+Additionally, the Liquidation contract serves as the point of calculation for partial collateral liquidations, where a loan position is liquidated until it reaches a safe borrow_amount / borrow_limit ratio. The required liquidation amount for each collateral is calculated based on the fed-in loan position's attributes and the state of the bid pools.
+The oracle contract is responsible for providing the relevant Cw20 token prices. Price data from the Oracle contract are only valid for 60 seconds (price_timeframe). The Liquidation contract disables bid executions until new price data is fed in to the Oracle contract.

--- a/contracts/market/README.md
+++ b/contracts/market/README.md
@@ -1,7 +1,7 @@
 # Market
 
-**NOTE**: Reference documentation for this contract is available [here](https://app.gitbook.com/@anchor-protocol/s/anchor-2/smart-contracts/money-market/market).
+**NOTE**: Reference documentation for this contract is available [here](https://docs.anchorprotocol.com/smart-contracts/money-market/market).
 
-The Market contract acts as the point of interaction for all lending and 
-borrowing related activities. New stablecoin deposits are added to this 
-contract's balance, while borrows are subtracted from the contract balance.
+The Market contract acts as the point of interaction for all lending and
+borrowing related activities. New stablecoin deposits are added to this
+contract's balance. Borrows are subtracted from this contract's balance.

--- a/contracts/oracle/README.md
+++ b/contracts/oracle/README.md
@@ -1,8 +1,8 @@
 # Oracle
 
-**NOTE**: Reference documentation for this contract is available [here](https://app.gitbook.com/@anchor-protocol/s/anchor-2/smart-contracts/money-market/oracle).
+**NOTE**: Reference documentation for this contract is available [here](https://docs.anchorprotocol.com/smart-contracts/money-market/oracle).
 
-The Oracle contract acts as the price source for the Anchor Money Market. 
-Stablecoin-denominated prices of bAssets are periodically reported by 
-oracle feeders, and are made queriable by other smart contracts in the 
+The Oracle contract acts as the price source for the Anchor Money Market.
+Stablecoin-denominated prices of bAssets are periodically reported by
+oracle feeders, and are made queriable by other smart contracts in the
 Anchor ecosystem.

--- a/contracts/overseer/README.md
+++ b/contracts/overseer/README.md
@@ -1,17 +1,15 @@
 # Overseer
 
-**NOTE**: Reference documentation for this contract is available [here](https://app.gitbook.com/@anchor-protocol/s/anchor-2/smart-contracts/money-market/overseer).
+**NOTE**: Reference documentation for this contract is available [here](https://docs.anchorprotocol.com/smart-contracts/money-market/overseer).
 
-The Overseer contract is responsible for storing key protocol parameters 
-and the whitelisting of new bAsset collaterals. The borrow limit of users 
-are calculated here, as the Overseer keeps track of locked collateral 
-amounts for all users.
+The Overseer contract is responsible for storing key protocol parameters
+and the whitelisting of new bAsset collaterals. The Overseer keeps track of locked collateral amounts and calculates the borrow limits for each user.
 
-This contract is the recipient for collected bAsset rewards claimed by 
-Custody contracts. The Overseer calculates the amount of depositor 
-subsidies that has to be distributed, and the resulting amount is sent to 
+This contract is the recipient for collected bAsset rewards claimed by
+Custody contracts. The Overseer calculates the amount of depositor
+subsidies to be distributed, and the resulting amount is sent to
 the Market contract.
 
-The Overseer halts borrow-related operations if the Oracle's price data is 
-older than 60 seconds `price_timeframe`. Operations are resumed when new 
+The Overseer halts borrow-related operations if the Oracle's price data is
+older than 60 seconds `price_timeframe`. Operations are resumed when new
 price data is fed-in.


### PR DESCRIPTION
## Summary of changes

Update broken main readme links contract readme links. 
Links updated to  docs.anchorprotocol.com domain from gitbook domains 
that require login.

Minor grammar and wording changes. 

Changes to the following readmes:
- bEth custody contract
- bLuna custody contract
- distribution model
- interest model
- liquidations
- liquidation queue
- market
- oracle
- overseer

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Added a relevant changelog entry to CHANGELOG.md

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
