### PR TITLE
feat: Collect staking rewards directly from custody contract 

### DIFF
--- a/contracts/custody_beth/Cargo.toml
+++ b/contracts/custody_beth/Cargo.toml
@@ -34,14 +34,15 @@ overflow-checks = true
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-moneymarket = { path = "../../packages/moneymarket", default-features = false, version = "0.3.1"}
-cw20 = "0.8"
-terra-cosmwasm = "2.2.0"
 cosmwasm-bignumber = "2.2.0"
 cosmwasm-std = "0.16.0"
 cosmwasm-storage = { version = "0.16.0", features = ["iterator"] }
+cw-storage-plus = "0.9.1"
+cw20 = "0.8"
+moneymarket = { path = "../../packages/moneymarket", default-features = false, version = "0.3.1"}
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+terra-cosmwasm = "2.2.0"
 thiserror = "1.0.2"
 
 [dev-dependencies]

--- a/contracts/custody_beth/src/collateral.rs
+++ b/contracts/custody_beth/src/collateral.rs
@@ -1,18 +1,13 @@
 use crate::error::ContractError;
-use crate::state::{
-    read_borrower_info, read_borrowers, read_config, remove_borrower_info, store_borrower_info,
-    BorrowerInfo, Config,
-};
+use crate::state::{read_borrower_info, read_borrowers, read_config, remove_borrower_info, store_borrower_info, BorrowerInfo, Config, update_user_rewards, save_user_rewards, read_user_rewards};
 
 use cosmwasm_bignumber::Uint256;
-use cosmwasm_std::{
-    attr, to_binary, Addr, CanonicalAddr, CosmosMsg, Deps, DepsMut, MessageInfo, Response,
-    StdResult, WasmMsg,
-};
+use cosmwasm_std::{attr, to_binary, Addr, CanonicalAddr, CosmosMsg, Deps, DepsMut, MessageInfo, Response, StdResult, WasmMsg, Coin, BankMsg};
 use cw20::Cw20ExecuteMsg;
 use moneymarket::custody::{BorrowerResponse, BorrowersResponse};
 use moneymarket::liquidation::Cw20HookMsg as LiquidationCw20HookMsg;
 use terra_cosmwasm::TerraMsgWrapper;
+use moneymarket::querier::deduct_tax;
 
 /// Deposit new collateral
 /// Executor: bAsset token contract
@@ -22,6 +17,7 @@ pub fn deposit_collateral(
     amount: Uint256,
 ) -> Result<Response<TerraMsgWrapper>, ContractError> {
     let borrower_raw = deps.api.addr_canonicalize(borrower.as_str())?;
+    update_user_rewards(deps.storage, &borrower_raw)?;
     let mut borrower_info: BorrowerInfo = read_borrower_info(deps.storage, &borrower_raw);
 
     // increase borrower collateral
@@ -48,6 +44,7 @@ pub fn withdraw_collateral(
 
     let borrower = info.sender;
     let borrower_raw = deps.api.addr_canonicalize(borrower.as_str())?;
+    update_user_rewards(deps.storage, &borrower_raw)?;
     let mut borrower_info: BorrowerInfo = read_borrower_info(deps.storage, &borrower_raw);
 
     // Check spendable balance
@@ -164,6 +161,7 @@ pub fn liquidate_collateral(
     }
 
     let borrower_raw: CanonicalAddr = deps.api.addr_canonicalize(borrower.as_str())?;
+    update_user_rewards(deps.storage, &borrower_raw)?;
     let mut borrower_info: BorrowerInfo = read_borrower_info(deps.storage, &borrower_raw);
     let locked_amount = borrower_info.balance - borrower_info.spendable;
     if amount > locked_amount {
@@ -207,6 +205,30 @@ pub fn liquidate_collateral(
             attr("borrower", borrower),
             attr("amount", amount),
         ]))
+}
+
+pub fn withdraw_staking_rewards(
+    deps: DepsMut,
+    info: MessageInfo,
+) -> Result<Response<TerraMsgWrapper>, ContractError> {
+    let borrower_raw = deps.api.addr_canonicalize(info.sender.as_str())?;
+    let config = read_config(deps.storage)?;
+    update_user_rewards(deps.storage, &borrower_raw)?;
+
+    let mut user_rewards = read_user_rewards(deps.storage, &borrower_raw);
+    let amount = user_rewards.rewards;
+    user_rewards.rewards = Uint256::zero();
+    save_user_rewards(deps.storage, &borrower_raw, &user_rewards)?;
+    Ok(Response::new().add_message(CosmosMsg::Bank(BankMsg::Send {
+        to_address: info.sender.to_string(),
+        amount: vec![deduct_tax(
+            deps.as_ref(),
+            Coin {
+                denom: config.stable_denom,
+                amount: amount.into(),
+            },
+        )?],
+    })))
 }
 
 pub fn query_borrower(deps: Deps, borrower: Addr) -> StdResult<BorrowerResponse> {

--- a/contracts/custody_beth/src/collateral.rs
+++ b/contracts/custody_beth/src/collateral.rs
@@ -1,13 +1,20 @@
-use crate::error::ContractError;
-use crate::state::{read_borrower_info, read_borrowers, read_config, remove_borrower_info, store_borrower_info, BorrowerInfo, Config, update_user_rewards, save_user_rewards, read_user_rewards};
-
 use cosmwasm_bignumber::Uint256;
-use cosmwasm_std::{attr, to_binary, Addr, CanonicalAddr, CosmosMsg, Deps, DepsMut, MessageInfo, Response, StdResult, WasmMsg, Coin, BankMsg};
+use cosmwasm_std::{
+    attr, to_binary, Addr, BankMsg, CanonicalAddr, Coin, CosmosMsg, Deps, DepsMut, MessageInfo,
+    Response, StdResult, WasmMsg,
+};
 use cw20::Cw20ExecuteMsg;
+use terra_cosmwasm::TerraMsgWrapper;
+
 use moneymarket::custody::{BorrowerResponse, BorrowersResponse};
 use moneymarket::liquidation::Cw20HookMsg as LiquidationCw20HookMsg;
-use terra_cosmwasm::TerraMsgWrapper;
 use moneymarket::querier::deduct_tax;
+
+use crate::error::ContractError;
+use crate::state::{
+    read_borrower_info, read_borrowers, read_config, read_user_rewards, remove_borrower_info,
+    save_user_rewards, store_borrower_info, update_user_rewards, BorrowerInfo, Config,
+};
 
 /// Deposit new collateral
 /// Executor: bAsset token contract

--- a/contracts/custody_beth/src/collateral.rs
+++ b/contracts/custody_beth/src/collateral.rs
@@ -222,7 +222,7 @@ pub fn withdraw_staking_rewards(
     let config = read_config(deps.storage)?;
     update_user_rewards(deps.storage, &borrower_raw)?;
 
-    let mut user_rewards = read_user_rewards(deps.storage, &borrower_raw);
+    let mut user_rewards = read_user_rewards(deps.storage, &borrower_raw)?;
     let amount = user_rewards.rewards;
     user_rewards.rewards = Uint256::zero();
     save_user_rewards(deps.storage, &borrower_raw, &user_rewards)?;

--- a/contracts/custody_beth/src/contract.rs
+++ b/contracts/custody_beth/src/contract.rs
@@ -2,12 +2,12 @@
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     attr, from_binary, to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response,
-    StdResult,
+    StdError, StdResult,
 };
 
 use crate::collateral::{
     deposit_collateral, liquidate_collateral, lock_collateral, query_borrower, query_borrowers,
-    unlock_collateral, withdraw_collateral,
+    unlock_collateral, withdraw_collateral, withdraw_staking_rewards,
 };
 use crate::distribution::{distribute_hook, distribute_rewards, swap_to_stable_denom};
 use crate::error::ContractError;
@@ -84,6 +84,7 @@ pub fn execute(
             let borrower_addr = deps.api.addr_validate(&borrower)?;
             liquidate_collateral(deps, info, liquidator_addr, borrower_addr, amount)
         }
+        ExecuteMsg::WithdrawStakingRewards {} => withdraw_staking_rewards(deps, info),
     }
 }
 
@@ -161,6 +162,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             optional_addr_validate(deps.api, start_after)?,
             limit,
         )?),
+        QueryMsg::TotalCumulativeRewards {} => Err(StdError::generic_err("Not implemented")),
     }
 }
 

--- a/contracts/custody_beth/src/contract.rs
+++ b/contracts/custody_beth/src/contract.rs
@@ -16,7 +16,7 @@ use crate::collateral::{
 };
 use crate::distribution::{distribute_hook, distribute_rewards, swap_to_stable_denom};
 use crate::error::ContractError;
-use crate::state::{read_config, read_total_cumulative_rewards, store_config, Config};
+use crate::state::{read_config, read_rewards_info, store_config, Config};
 
 pub const CLAIM_REWARDS_OPERATION: u64 = 1u64;
 pub const SWAP_TO_STABLE_OPERATION: u64 = 2u64;
@@ -162,9 +162,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             optional_addr_validate(deps.api, start_after)?,
             limit,
         )?),
-        QueryMsg::TotalCumulativeRewards {} => {
-            to_binary(&read_total_cumulative_rewards(deps.storage))
-        }
+        QueryMsg::RewardsInfo {} => to_binary(&read_rewards_info(deps.storage)),
     }
 }
 

--- a/contracts/custody_beth/src/contract.rs
+++ b/contracts/custody_beth/src/contract.rs
@@ -4,6 +4,11 @@ use cosmwasm_std::{
     attr, from_binary, to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response,
     StdResult,
 };
+use cw20::Cw20ReceiveMsg;
+use terra_cosmwasm::TerraMsgWrapper;
+
+use moneymarket::common::optional_addr_validate;
+use moneymarket::custody::{ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
 
 use crate::collateral::{
     deposit_collateral, liquidate_collateral, lock_collateral, query_borrower, query_borrowers,
@@ -11,12 +16,7 @@ use crate::collateral::{
 };
 use crate::distribution::{distribute_hook, distribute_rewards, swap_to_stable_denom};
 use crate::error::ContractError;
-use crate::state::{read_config, store_config, Config, read_total_cumulative_rewards};
-
-use cw20::Cw20ReceiveMsg;
-use moneymarket::common::optional_addr_validate;
-use moneymarket::custody::{ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
-use terra_cosmwasm::TerraMsgWrapper;
+use crate::state::{read_config, read_total_cumulative_rewards, store_config, Config};
 
 pub const CLAIM_REWARDS_OPERATION: u64 = 1u64;
 pub const SWAP_TO_STABLE_OPERATION: u64 = 2u64;

--- a/contracts/custody_beth/src/contract.rs
+++ b/contracts/custody_beth/src/contract.rs
@@ -162,7 +162,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             optional_addr_validate(deps.api, start_after)?,
             limit,
         )?),
-        QueryMsg::RewardsInfo {} => to_binary(&read_rewards_info(deps.storage)),
+        QueryMsg::RewardsInfo {} => to_binary(&read_rewards_info(deps.storage)?),
     }
 }
 

--- a/contracts/custody_beth/src/contract.rs
+++ b/contracts/custody_beth/src/contract.rs
@@ -2,7 +2,7 @@
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     attr, from_binary, to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response,
-    StdError, StdResult,
+    StdResult,
 };
 
 use crate::collateral::{
@@ -11,7 +11,7 @@ use crate::collateral::{
 };
 use crate::distribution::{distribute_hook, distribute_rewards, swap_to_stable_denom};
 use crate::error::ContractError;
-use crate::state::{read_config, store_config, Config};
+use crate::state::{read_config, store_config, Config, read_total_cumulative_rewards};
 
 use cw20::Cw20ReceiveMsg;
 use moneymarket::common::optional_addr_validate;
@@ -162,7 +162,9 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             optional_addr_validate(deps.api, start_after)?,
             limit,
         )?),
-        QueryMsg::TotalCumulativeRewards {} => Err(StdError::generic_err("Not implemented")),
+        QueryMsg::TotalCumulativeRewards {} => {
+            to_binary(&read_total_cumulative_rewards(deps.storage))
+        }
     }
 }
 

--- a/contracts/custody_beth/src/distribution.rs
+++ b/contracts/custody_beth/src/distribution.rs
@@ -3,14 +3,17 @@ use cosmwasm_std::{
     attr, to_binary, Addr, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo, QueryRequest,
     ReplyOn, Response, StdResult, SubMsg, Uint128, WasmMsg, WasmQuery,
 };
+use terra_cosmwasm::{create_swap_msg, TerraMsgWrapper};
+
+use moneymarket::querier::{deduct_tax, query_all_balances, query_balance, query_token_balance};
 
 use crate::contract::{CLAIM_REWARDS_OPERATION, SWAP_TO_STABLE_OPERATION};
 use crate::error::ContractError;
 use crate::external::handle::{RewardContractExecuteMsg, RewardContractQueryMsg};
-use crate::state::{read_config, BETHAccruedRewardsResponse, Config, update_global_index, update_total_cumulative_rewards};
-
-use moneymarket::querier::{deduct_tax, query_all_balances, query_balance, query_token_balance};
-use terra_cosmwasm::{create_swap_msg, TerraMsgWrapper};
+use crate::state::{
+    read_config, update_global_index, update_total_cumulative_rewards, BETHAccruedRewardsResponse,
+    Config,
+};
 
 // REWARD_THRESHOLD
 // This value is used as the minimum reward claim amount

--- a/contracts/custody_beth/src/distribution.rs
+++ b/contracts/custody_beth/src/distribution.rs
@@ -7,7 +7,7 @@ use cosmwasm_std::{
 use crate::contract::{CLAIM_REWARDS_OPERATION, SWAP_TO_STABLE_OPERATION};
 use crate::error::ContractError;
 use crate::external::handle::{RewardContractExecuteMsg, RewardContractQueryMsg};
-use crate::state::{read_config, BETHAccruedRewardsResponse, Config, update_global_index};
+use crate::state::{read_config, BETHAccruedRewardsResponse, Config, update_global_index, update_total_cumulative_rewards};
 
 use moneymarket::querier::{deduct_tax, query_all_balances, query_balance, query_token_balance};
 use terra_cosmwasm::{create_swap_msg, TerraMsgWrapper};
@@ -74,6 +74,7 @@ pub fn distribute_hook(
     )?;
 
     update_global_index(deps.storage, &reward_amount, &collateral_amount)?;
+    update_total_cumulative_rewards(deps.storage, &reward_amount)?;
 
     Ok(Response::new().add_attributes(vec![
         attr("action", "distribute_rewards"),

--- a/contracts/custody_beth/src/state.rs
+++ b/contracts/custody_beth/src/state.rs
@@ -1,9 +1,9 @@
+use cosmwasm_bignumber::{Decimal256, Uint256};
+use cosmwasm_std::{CanonicalAddr, Deps, Order, StdResult, Storage, Uint128};
+use cosmwasm_storage::{Bucket, ReadonlyBucket, ReadonlySingleton, Singleton};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_bignumber::Uint256;
-use cosmwasm_std::{CanonicalAddr, Deps, Order, StdResult, Storage, Uint128};
-use cosmwasm_storage::{Bucket, ReadonlyBucket, ReadonlySingleton, Singleton};
 use moneymarket::custody::{BAssetInfo, BorrowerResponse};
 
 //BETHAccruedRewardsResponse the struct that shows the result of accrued_rewards query

--- a/contracts/custody_beth/src/state.rs
+++ b/contracts/custody_beth/src/state.rs
@@ -106,3 +106,57 @@ fn calc_range_start(start_after: Option<CanonicalAddr>) -> Option<Vec<u8>> {
         v
     })
 }
+
+// rewards / collateral
+const KEY_GLOBAL_INDEX: &[u8] = b"global_index";
+const KEY_USER_REWARDS: &[u8] = b"user_rewards";
+const KEY_TOTAL_CUMULATIVE_REWARDS: &[u8] = b"total_cumulative_rewards";
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
+pub struct UserRewards {
+    pub user_index: Decimal256,
+    pub rewards: Uint256,
+}
+
+pub fn save_global_index(storage: &mut dyn Storage, data: &Decimal256) -> StdResult<()> {
+    Singleton::new(storage, KEY_GLOBAL_INDEX).save(data)
+}
+
+pub fn read_global_index(storage: &dyn Storage) -> Decimal256 {
+    ReadonlySingleton::new(storage, KEY_GLOBAL_INDEX)
+        .load()
+        .unwrap_or_else(|_| Decimal256::zero())
+}
+
+pub fn update_global_index(
+    storage: &mut dyn Storage,
+    reward_amount: &Uint256,
+    collateral_amount: &Uint256,
+) -> StdResult<()> {
+    let mut current = read_global_index(storage);
+    current += Decimal256::from_ratio(*reward_amount, *collateral_amount);
+    save_global_index(storage, &current)
+}
+
+pub fn save_user_rewards(
+    storage: &mut dyn Storage,
+    borrower: &CanonicalAddr,
+    new_rewards: &UserRewards,
+) -> StdResult<()> {
+    let mut user_index_bucket = Bucket::new(storage, KEY_USER_REWARDS);
+    user_index_bucket.save(borrower, new_rewards)
+}
+
+pub fn read_user_rewards(storage: &dyn Storage, borrower: &CanonicalAddr) -> UserRewards {
+    let user_index_bucket = ReadonlyBucket::new(storage, KEY_USER_REWARDS);
+    user_index_bucket.load(borrower).unwrap_or_default()
+}
+
+pub fn update_user_rewards(storage: &mut dyn Storage, borrower: &CanonicalAddr) -> StdResult<()> {
+    let global_index = read_global_index(storage);
+    let mut user_rewards = read_user_rewards(storage, borrower);
+    let borrower_info = read_borrower_info(storage, borrower);
+    user_rewards.rewards += borrower_info.balance * (global_index - user_rewards.user_index);
+    user_rewards.user_index = global_index;
+    save_user_rewards(storage, borrower, &user_rewards)
+}

--- a/contracts/custody_beth/src/state.rs
+++ b/contracts/custody_beth/src/state.rs
@@ -1,6 +1,7 @@
 use cosmwasm_bignumber::{Decimal256, Uint256};
 use cosmwasm_std::{CanonicalAddr, Deps, Order, StdResult, Storage, Uint128};
 use cosmwasm_storage::{Bucket, ReadonlyBucket, ReadonlySingleton, Singleton};
+use cw_storage_plus::{Item, Map};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -14,8 +15,9 @@ pub struct BETHAccruedRewardsResponse {
 
 const PREFIX_BORROWER: &[u8] = b"borrower";
 const KEY_CONFIG: &[u8] = b"config";
-const KEY_REWARDS_INFO: &[u8] = b"rewards_info";
-const KEY_USER_REWARDS: &[u8] = b"user_rewards";
+
+const REWARDS_INFO: Item<RewardsInfo> = Item::new("rewards_info");
+const USER_REWARDS: Map<&[u8], UserRewards> = Map::new("user_rewards");
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
@@ -122,13 +124,13 @@ fn calc_range_start(start_after: Option<CanonicalAddr>) -> Option<Vec<u8>> {
 }
 
 pub fn save_rewards_info(storage: &mut dyn Storage, data: &RewardsInfo) -> StdResult<()> {
-    Singleton::new(storage, KEY_REWARDS_INFO).save(data)
+    REWARDS_INFO.save(storage, data)
 }
 
-pub fn read_rewards_info(storage: &dyn Storage) -> RewardsInfo {
-    ReadonlySingleton::new(storage, KEY_REWARDS_INFO)
-        .load()
-        .unwrap_or_else(|_| RewardsInfo::default())
+pub fn read_rewards_info(storage: &dyn Storage) -> StdResult<RewardsInfo> {
+    REWARDS_INFO
+        .may_load(storage)
+        .map(Option::unwrap_or_default)
 }
 
 pub fn update_rewards_info(
@@ -136,7 +138,7 @@ pub fn update_rewards_info(
     reward_amount: &Uint256,
     collateral_amount: &Uint256,
 ) -> StdResult<()> {
-    let mut current = read_rewards_info(storage);
+    let mut current = REWARDS_INFO.may_load(storage)?.unwrap_or_default();
     current.global_index += Decimal256::from_ratio(*reward_amount, *collateral_amount);
     current.cumulative_total += *reward_amount;
     save_rewards_info(storage, &current)
@@ -147,18 +149,21 @@ pub fn save_user_rewards(
     borrower: &CanonicalAddr,
     new_rewards: &UserRewards,
 ) -> StdResult<()> {
-    let mut user_index_bucket = Bucket::new(storage, KEY_USER_REWARDS);
-    user_index_bucket.save(borrower, new_rewards)
+    USER_REWARDS.save(storage, borrower.as_slice(), new_rewards)
 }
 
-pub fn read_user_rewards(storage: &dyn Storage, borrower: &CanonicalAddr) -> UserRewards {
-    let user_index_bucket = ReadonlyBucket::new(storage, KEY_USER_REWARDS);
-    user_index_bucket.load(borrower).unwrap_or_default()
+pub fn read_user_rewards(
+    storage: &dyn Storage,
+    borrower: &CanonicalAddr,
+) -> StdResult<UserRewards> {
+    USER_REWARDS
+        .may_load(storage, borrower.as_slice())
+        .map(Option::unwrap_or_default)
 }
 
 pub fn update_user_rewards(storage: &mut dyn Storage, borrower: &CanonicalAddr) -> StdResult<()> {
-    let global_index = read_rewards_info(storage).global_index;
-    let mut user_rewards = read_user_rewards(storage, borrower);
+    let global_index = read_rewards_info(storage)?.global_index;
+    let mut user_rewards = read_user_rewards(storage, borrower)?;
     let borrower_info = read_borrower_info(storage, borrower);
     user_rewards.rewards += borrower_info.balance * (global_index - user_rewards.user_index);
     user_rewards.user_index = global_index;

--- a/contracts/custody_beth/src/state.rs
+++ b/contracts/custody_beth/src/state.rs
@@ -160,3 +160,23 @@ pub fn update_user_rewards(storage: &mut dyn Storage, borrower: &CanonicalAddr) 
     user_rewards.user_index = global_index;
     save_user_rewards(storage, borrower, &user_rewards)
 }
+
+pub fn save_total_cumulative_rewards(
+    storage: &mut dyn Storage,
+    new_rewards: &Uint256,
+) -> StdResult<()> {
+    let mut rewards = Singleton::new(storage, KEY_TOTAL_CUMULATIVE_REWARDS);
+    rewards.save(new_rewards)
+}
+
+pub fn read_total_cumulative_rewards(storage: &dyn Storage) -> Uint256 {
+    ReadonlySingleton::new(storage, KEY_TOTAL_CUMULATIVE_REWARDS)
+        .load()
+        .unwrap_or_else(|_| Uint256::zero())
+}
+
+pub fn update_total_cumulative_rewards(storage: &mut dyn Storage, data: &Uint256) -> StdResult<()> {
+    let mut current = read_total_cumulative_rewards(storage);
+    current += *data;
+    save_total_cumulative_rewards(storage, &current)
+}

--- a/contracts/custody_beth/src/testing/mock_querier.rs
+++ b/contracts/custody_beth/src/testing/mock_querier.rs
@@ -1,5 +1,5 @@
-use crate::external::handle::RewardContractQueryMsg;
-use crate::state::BETHAccruedRewardsResponse;
+use std::collections::HashMap;
+
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
     from_binary, from_slice, to_binary, Addr, Api, BalanceResponse, BankQuery, CanonicalAddr, Coin,
@@ -8,8 +8,10 @@ use cosmwasm_std::{
 };
 use cosmwasm_storage::to_length_prefixed;
 use cw20::{BalanceResponse as Cw20BalanceResponse, Cw20QueryMsg, TokenInfoResponse};
-use std::collections::HashMap;
 use terra_cosmwasm::{TaxCapResponse, TaxRateResponse, TerraQuery, TerraQueryWrapper, TerraRoute};
+
+use crate::external::handle::RewardContractQueryMsg;
+use crate::state::BETHAccruedRewardsResponse;
 
 /// mock_dependencies is a drop-in replacement for cosmwasm_std::testing::mock_dependencies
 /// this uses our CustomQuerier.

--- a/contracts/custody_beth/src/testing/tests.rs
+++ b/contracts/custody_beth/src/testing/tests.rs
@@ -426,7 +426,7 @@ fn lock_collateral() {
     //directly checking if spendable is decreased by amount
     let spend = read_borrower_info(
         &deps.storage,
-        &deps.api.addr_canonicalize(&"addr0000".to_string()).unwrap(),
+        &deps.api.addr_canonicalize("addr0000").unwrap(),
     )
     .spendable;
     assert_eq!(spend, Uint256::from(50u128));
@@ -513,7 +513,7 @@ fn lock_collateral() {
     //checking if amount is added to spendable
     let spend = read_borrower_info(
         &deps.storage,
-        &deps.api.addr_canonicalize(&"addr0000".to_string()).unwrap(),
+        &deps.api.addr_canonicalize("addr0000").unwrap(),
     )
     .spendable;
     assert_eq!(spend, Uint256::from(30u128));

--- a/contracts/custody_beth/src/testing/tests.rs
+++ b/contracts/custody_beth/src/testing/tests.rs
@@ -834,7 +834,7 @@ fn swap_to_stable_denom() {
 
     // mimic callback from distribute_rewards to execute swap_to_stable_denom
     let reply_msg = Reply {
-        id: 1,
+        id: CLAIM_REWARDS_OPERATION,
         result: ContractResult::Ok(SubMsgExecutionResponse {
             events: vec![],
             data: None,

--- a/contracts/custody_beth/src/testing/tests.rs
+++ b/contracts/custody_beth/src/testing/tests.rs
@@ -665,12 +665,12 @@ fn distribute_hook() {
         ]
     );
 
-    let rewards_info = read_rewards_info(&deps.storage);
-    assert_eq!(rewards_info.global_index.to_string(), "1000".to_string());
-
     assert_eq!(
-        rewards_info.cumulative_total,
-        Uint256::from(1000000u128)
+        read_rewards_info(&deps.storage).unwrap(),
+        RewardsInfo {
+            global_index: Decimal256::from_uint256(1000u128),
+            cumulative_total: Uint256::from(1000000u128),
+        }
     );
 }
 
@@ -724,13 +724,11 @@ fn distribution_hook_zero_rewards() {
     assert_eq!(res.messages, vec![],);
 
     assert_eq!(
-        read_rewards_info(&deps.storage).global_index.to_string(),
-        "0".to_string()
-    );
-
-    assert_eq!(
-        read_rewards_info(&deps.storage).cumulative_total,
-        Uint256::zero()
+        read_rewards_info(&deps.storage).unwrap(),
+        RewardsInfo {
+            global_index: Decimal256::zero(),
+            cumulative_total: Uint256::zero(),
+        }
     );
 }
 
@@ -775,7 +773,7 @@ fn withdraws_staking_rewards() {
     );
 
     assert_eq!(
-        read_user_rewards(&deps.storage, &deps.api.addr_canonicalize(ADDR).unwrap()),
+        read_user_rewards(&deps.storage, &deps.api.addr_canonicalize(ADDR).unwrap()).unwrap(),
         UserRewards {
             user_index: Decimal256::zero(),
             rewards: Uint256::from(1000000u128),
@@ -786,7 +784,7 @@ fn withdraws_staking_rewards() {
     let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     assert_eq!(
-        read_user_rewards(&deps.storage, &deps.api.addr_canonicalize(ADDR).unwrap()),
+        read_user_rewards(&deps.storage, &deps.api.addr_canonicalize(ADDR).unwrap()).unwrap(),
         UserRewards {
             user_index: Decimal256::from_uint256(999u128),
             rewards: Uint256::zero(),

--- a/contracts/custody_beth/src/testing/tests.rs
+++ b/contracts/custody_beth/src/testing/tests.rs
@@ -17,7 +17,10 @@ use crate::contract::{
 };
 use crate::error::ContractError;
 use crate::external::handle::RewardContractExecuteMsg;
-use crate::state::{read_borrower_info, read_global_index, read_user_rewards, save_global_index, save_user_rewards, BETHAccruedRewardsResponse, UserRewards, read_total_cumulative_rewards};
+use crate::state::{
+    read_borrower_info, read_global_index, read_total_cumulative_rewards, read_user_rewards,
+    save_global_index, save_user_rewards, BETHAccruedRewardsResponse, UserRewards,
+};
 use crate::testing::mock_querier::mock_dependencies;
 
 #[test]

--- a/contracts/custody_bluna/Cargo.toml
+++ b/contracts/custody_bluna/Cargo.toml
@@ -34,14 +34,15 @@ overflow-checks = true
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-moneymarket = { path = "../../packages/moneymarket", default-features = false, version = "0.3.1"}
-cw20 = "0.8.0"
-terra-cosmwasm = "2.2.0"
 cosmwasm-bignumber = "2.2.0"
 cosmwasm-std = "0.16.0"
 cosmwasm-storage = { version = "0.16.0", features = ["iterator"] }
+cw-storage-plus = "0.9.1"
+cw20 = "0.8.0"
+moneymarket = { path = "../../packages/moneymarket", default-features = false, version = "0.3.1"}
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+terra-cosmwasm = "2.2.0"
 thiserror = "1.0.2"
 
 [dev-dependencies]

--- a/contracts/custody_bluna/src/collateral.rs
+++ b/contracts/custody_bluna/src/collateral.rs
@@ -1,19 +1,20 @@
-use crate::error::ContractError;
-use crate::state::{
-    read_borrower_info, read_borrowers, read_config, read_user_rewards, remove_borrower_info,
-    save_user_rewards, store_borrower_info, update_user_rewards, BorrowerInfo, Config,
-};
-
 use cosmwasm_bignumber::Uint256;
 use cosmwasm_std::{
     attr, to_binary, Addr, BankMsg, CanonicalAddr, Coin, CosmosMsg, Deps, DepsMut, MessageInfo,
     Response, StdResult, WasmMsg,
 };
 use cw20::Cw20ExecuteMsg;
+use terra_cosmwasm::TerraMsgWrapper;
+
 use moneymarket::custody::{BorrowerResponse, BorrowersResponse};
 use moneymarket::liquidation::Cw20HookMsg as LiquidationCw20HookMsg;
 use moneymarket::querier::deduct_tax;
-use terra_cosmwasm::TerraMsgWrapper;
+
+use crate::error::ContractError;
+use crate::state::{
+    read_borrower_info, read_borrowers, read_config, read_user_rewards, remove_borrower_info,
+    save_user_rewards, store_borrower_info, update_user_rewards, BorrowerInfo, Config,
+};
 
 /// Deposit new collateral
 /// Executor: bAsset token contract

--- a/contracts/custody_bluna/src/collateral.rs
+++ b/contracts/custody_bluna/src/collateral.rs
@@ -222,7 +222,7 @@ pub fn withdraw_staking_rewards(
     let config = read_config(deps.storage)?;
     update_user_rewards(deps.storage, &borrower_raw)?;
 
-    let mut user_rewards = read_user_rewards(deps.storage, &borrower_raw);
+    let mut user_rewards = read_user_rewards(deps.storage, &borrower_raw)?;
     let amount = user_rewards.rewards;
     user_rewards.rewards = Uint256::zero();
     save_user_rewards(deps.storage, &borrower_raw, &user_rewards)?;

--- a/contracts/custody_bluna/src/collateral.rs
+++ b/contracts/custody_bluna/src/collateral.rs
@@ -1,17 +1,18 @@
 use crate::error::ContractError;
 use crate::state::{
-    read_borrower_info, read_borrowers, read_config, remove_borrower_info, store_borrower_info,
-    BorrowerInfo, Config,
+    read_borrower_info, read_borrowers, read_config, read_user_rewards, remove_borrower_info,
+    save_user_rewards, store_borrower_info, update_user_rewards, BorrowerInfo, Config,
 };
 
 use cosmwasm_bignumber::Uint256;
 use cosmwasm_std::{
-    attr, to_binary, Addr, CanonicalAddr, CosmosMsg, Deps, DepsMut, MessageInfo, Response,
-    StdResult, WasmMsg,
+    attr, to_binary, Addr, BankMsg, CanonicalAddr, Coin, CosmosMsg, Deps, DepsMut, MessageInfo,
+    Response, StdResult, WasmMsg,
 };
 use cw20::Cw20ExecuteMsg;
 use moneymarket::custody::{BorrowerResponse, BorrowersResponse};
 use moneymarket::liquidation::Cw20HookMsg as LiquidationCw20HookMsg;
+use moneymarket::querier::deduct_tax;
 use terra_cosmwasm::TerraMsgWrapper;
 
 /// Deposit new collateral
@@ -22,6 +23,7 @@ pub fn deposit_collateral(
     amount: Uint256,
 ) -> Result<Response<TerraMsgWrapper>, ContractError> {
     let borrower_raw = deps.api.addr_canonicalize(borrower.as_str())?;
+    update_user_rewards(deps.storage, &borrower_raw)?;
     let mut borrower_info: BorrowerInfo = read_borrower_info(deps.storage, &borrower_raw);
 
     // increase borrower collateral
@@ -48,6 +50,7 @@ pub fn withdraw_collateral(
 
     let borrower = info.sender;
     let borrower_raw = deps.api.addr_canonicalize(borrower.as_str())?;
+    update_user_rewards(deps.storage, &borrower_raw)?;
     let mut borrower_info: BorrowerInfo = read_borrower_info(deps.storage, &borrower_raw);
 
     // Check spendable balance
@@ -164,6 +167,7 @@ pub fn liquidate_collateral(
     }
 
     let borrower_raw: CanonicalAddr = deps.api.addr_canonicalize(borrower.as_str())?;
+    update_user_rewards(deps.storage, &borrower_raw)?;
     let mut borrower_info: BorrowerInfo = read_borrower_info(deps.storage, &borrower_raw);
     let borrowed_amt = borrower_info.balance - borrower_info.spendable;
     if amount > borrowed_amt {
@@ -207,6 +211,30 @@ pub fn liquidate_collateral(
             attr("borrower", borrower),
             attr("amount", amount),
         ]))
+}
+
+pub fn withdraw_staking_rewards(
+    deps: DepsMut,
+    info: MessageInfo,
+) -> Result<Response<TerraMsgWrapper>, ContractError> {
+    let borrower_raw = deps.api.addr_canonicalize(info.sender.as_str())?;
+    let config = read_config(deps.storage)?;
+    update_user_rewards(deps.storage, &borrower_raw)?;
+
+    let mut user_rewards = read_user_rewards(deps.storage, &borrower_raw);
+    let amount = user_rewards.rewards;
+    user_rewards.rewards = Uint256::zero();
+    save_user_rewards(deps.storage, &borrower_raw, &user_rewards)?;
+    Ok(Response::new().add_message(CosmosMsg::Bank(BankMsg::Send {
+        to_address: info.sender.to_string(),
+        amount: vec![deduct_tax(
+            deps.as_ref(),
+            Coin {
+                denom: config.stable_denom,
+                amount: amount.into(),
+            },
+        )?],
+    })))
 }
 
 pub fn query_borrower(deps: Deps, borrower: Addr) -> StdResult<BorrowerResponse> {

--- a/contracts/custody_bluna/src/contract.rs
+++ b/contracts/custody_bluna/src/contract.rs
@@ -1,9 +1,14 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    Addr, attr, Binary, Deps, DepsMut, Env, from_binary, MessageInfo, Reply, Response, StdResult,
-    to_binary,
+    attr, from_binary, to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response,
+    StdResult,
 };
+use cw20::Cw20ReceiveMsg;
+use terra_cosmwasm::TerraMsgWrapper;
+
+use moneymarket::common::optional_addr_validate;
+use moneymarket::custody::{ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
 
 use crate::collateral::{
     deposit_collateral, liquidate_collateral, lock_collateral, query_borrower, query_borrowers,
@@ -11,12 +16,7 @@ use crate::collateral::{
 };
 use crate::distribution::{distribute_hook, distribute_rewards, swap_to_stable_denom};
 use crate::error::ContractError;
-use crate::state::{Config, read_config, store_config, read_total_cumulative_rewards};
-
-use cw20::Cw20ReceiveMsg;
-use moneymarket::common::optional_addr_validate;
-use moneymarket::custody::{ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
-use terra_cosmwasm::TerraMsgWrapper;
+use crate::state::{read_config, read_total_cumulative_rewards, store_config, Config};
 
 pub const CLAIM_REWARDS_OPERATION: u64 = 1u64;
 pub const SWAP_TO_STABLE_OPERATION: u64 = 2u64;

--- a/contracts/custody_bluna/src/contract.rs
+++ b/contracts/custody_bluna/src/contract.rs
@@ -7,11 +7,11 @@ use cosmwasm_std::{
 
 use crate::collateral::{
     deposit_collateral, liquidate_collateral, lock_collateral, query_borrower, query_borrowers,
-    unlock_collateral, withdraw_collateral,
+    unlock_collateral, withdraw_collateral, withdraw_staking_rewards,
 };
 use crate::distribution::{distribute_hook, distribute_rewards, swap_to_stable_denom};
 use crate::error::ContractError;
-use crate::state::{read_config, store_config, Config};
+use crate::state::{read_config, read_total_cumulative_rewards, store_config, Config};
 
 use cw20::Cw20ReceiveMsg;
 use moneymarket::common::optional_addr_validate;
@@ -75,6 +75,7 @@ pub fn execute(
         }
         ExecuteMsg::DistributeRewards {} => distribute_rewards(deps, env, info),
         ExecuteMsg::WithdrawCollateral { amount } => withdraw_collateral(deps, info, amount),
+        ExecuteMsg::WithdrawStakingRewards {} => withdraw_staking_rewards(deps, info),
         ExecuteMsg::LiquidateCollateral {
             liquidator,
             borrower,
@@ -160,7 +161,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             deps,
             optional_addr_validate(deps.api, start_after)?,
             limit,
-        )?),
+        )?)
     }
 }
 

--- a/contracts/custody_bluna/src/contract.rs
+++ b/contracts/custody_bluna/src/contract.rs
@@ -16,7 +16,7 @@ use crate::collateral::{
 };
 use crate::distribution::{distribute_hook, distribute_rewards, swap_to_stable_denom};
 use crate::error::ContractError;
-use crate::state::{read_config, read_total_cumulative_rewards, store_config, Config};
+use crate::state::{read_config, read_rewards_info, store_config, Config};
 
 pub const CLAIM_REWARDS_OPERATION: u64 = 1u64;
 pub const SWAP_TO_STABLE_OPERATION: u64 = 2u64;
@@ -162,9 +162,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             optional_addr_validate(deps.api, start_after)?,
             limit,
         )?),
-        QueryMsg::TotalCumulativeRewards {} => {
-            to_binary(&read_total_cumulative_rewards(deps.storage))
-        }
+        QueryMsg::RewardsInfo {} => to_binary(&read_rewards_info(deps.storage)),
     }
 }
 

--- a/contracts/custody_bluna/src/contract.rs
+++ b/contracts/custody_bluna/src/contract.rs
@@ -162,7 +162,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             optional_addr_validate(deps.api, start_after)?,
             limit,
         )?),
-        QueryMsg::RewardsInfo {} => to_binary(&read_rewards_info(deps.storage)),
+        QueryMsg::RewardsInfo {} => to_binary(&read_rewards_info(deps.storage)?),
     }
 }
 

--- a/contracts/custody_bluna/src/contract.rs
+++ b/contracts/custody_bluna/src/contract.rs
@@ -1,8 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    attr, from_binary, to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response,
-    StdResult,
+    Addr, attr, Binary, Deps, DepsMut, Env, from_binary, MessageInfo, Reply, Response, StdResult,
+    to_binary,
 };
 
 use crate::collateral::{
@@ -11,7 +11,7 @@ use crate::collateral::{
 };
 use crate::distribution::{distribute_hook, distribute_rewards, swap_to_stable_denom};
 use crate::error::ContractError;
-use crate::state::{read_config, read_total_cumulative_rewards, store_config, Config};
+use crate::state::{Config, read_config, store_config, read_total_cumulative_rewards};
 
 use cw20::Cw20ReceiveMsg;
 use moneymarket::common::optional_addr_validate;
@@ -161,7 +161,10 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             deps,
             optional_addr_validate(deps.api, start_after)?,
             limit,
-        )?)
+        )?),
+        QueryMsg::TotalCumulativeRewards {} => {
+            to_binary(&read_total_cumulative_rewards(deps.storage))
+        }
     }
 }
 

--- a/contracts/custody_bluna/src/distribution.rs
+++ b/contracts/custody_bluna/src/distribution.rs
@@ -7,9 +7,7 @@ use cosmwasm_std::{
 use crate::contract::{CLAIM_REWARDS_OPERATION, SWAP_TO_STABLE_OPERATION};
 use crate::error::ContractError;
 use crate::external::handle::{RewardContractExecuteMsg, RewardContractQueryMsg};
-use crate::state::{
-    read_config, update_global_index, BLunaAccruedRewardsResponse, Config,
-};
+use crate::state::{read_config, update_global_index, BLunaAccruedRewardsResponse, Config, update_total_cumulative_rewards};
 
 use moneymarket::querier::{query_all_balances, query_balance, query_token_balance};
 use terra_cosmwasm::{create_swap_msg, TerraMsgWrapper};
@@ -78,6 +76,7 @@ pub fn distribute_hook(
     )?;
 
     update_global_index(deps.storage, &reward_amount, &collateral_amount)?;
+    update_total_cumulative_rewards(deps.storage, &reward_amount)?;
 
     Ok(Response::new().add_attributes(vec![
         attr("action", "distribute_rewards"),

--- a/contracts/custody_bluna/src/distribution.rs
+++ b/contracts/custody_bluna/src/distribution.rs
@@ -1,15 +1,17 @@
 use cosmwasm_bignumber::Uint256;
 use cosmwasm_std::{
-    attr, to_binary, Addr, BankMsg, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo, QueryRequest,
-    ReplyOn, Response, StdResult, SubMsg, Uint128, WasmMsg, WasmQuery,
+    attr, to_binary, Addr, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo, QueryRequest, ReplyOn,
+    Response, StdResult, SubMsg, Uint128, WasmMsg, WasmQuery,
 };
 
 use crate::contract::{CLAIM_REWARDS_OPERATION, SWAP_TO_STABLE_OPERATION};
 use crate::error::ContractError;
 use crate::external::handle::{RewardContractExecuteMsg, RewardContractQueryMsg};
-use crate::state::{read_config, BLunaAccruedRewardsResponse, Config};
+use crate::state::{
+    read_config, update_global_index, BLunaAccruedRewardsResponse, Config,
+};
 
-use moneymarket::querier::{deduct_tax, query_all_balances, query_balance};
+use moneymarket::querier::{query_all_balances, query_balance, query_token_balance};
 use terra_cosmwasm::{create_swap_msg, TerraMsgWrapper};
 
 // REWARD_THRESHOLD
@@ -60,30 +62,24 @@ pub fn distribute_hook(
 ) -> Result<Response<TerraMsgWrapper>, ContractError> {
     let contract_addr = env.contract.address;
     let config: Config = read_config(deps.storage)?;
-    let overseer_contract = deps.api.addr_humanize(&config.overseer_contract)?;
 
     // reward_amount = (prev_balance + reward_amount) - prev_balance
     // = (0 + reward_amount) - 0 = reward_amount = balance
     let reward_amount: Uint256 = query_balance(
         deps.as_ref(),
-        contract_addr,
+        contract_addr.clone(),
         config.stable_denom.to_string(),
     )?;
-    let mut messages: Vec<CosmosMsg<TerraMsgWrapper>> = vec![];
-    if !reward_amount.is_zero() {
-        messages.push(CosmosMsg::Bank(BankMsg::Send {
-            to_address: overseer_contract.to_string(),
-            amount: vec![deduct_tax(
-                deps.as_ref(),
-                Coin {
-                    denom: config.stable_denom,
-                    amount: reward_amount.into(),
-                },
-            )?],
-        }));
-    }
 
-    Ok(Response::new().add_messages(messages).add_attributes(vec![
+    let collateral_amount: Uint256 = query_token_balance(
+        deps.as_ref(),
+        deps.api.addr_humanize(&config.collateral_token)?,
+        contract_addr,
+    )?;
+
+    update_global_index(deps.storage, &reward_amount, &collateral_amount)?;
+
+    Ok(Response::new().add_attributes(vec![
         attr("action", "distribute_rewards"),
         attr("buffer_rewards", reward_amount),
     ]))

--- a/contracts/custody_bluna/src/distribution.rs
+++ b/contracts/custody_bluna/src/distribution.rs
@@ -3,14 +3,17 @@ use cosmwasm_std::{
     attr, to_binary, Addr, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo, QueryRequest, ReplyOn,
     Response, StdResult, SubMsg, Uint128, WasmMsg, WasmQuery,
 };
+use terra_cosmwasm::{create_swap_msg, TerraMsgWrapper};
+
+use moneymarket::querier::{query_all_balances, query_balance, query_token_balance};
 
 use crate::contract::{CLAIM_REWARDS_OPERATION, SWAP_TO_STABLE_OPERATION};
 use crate::error::ContractError;
 use crate::external::handle::{RewardContractExecuteMsg, RewardContractQueryMsg};
-use crate::state::{read_config, update_global_index, BLunaAccruedRewardsResponse, Config, update_total_cumulative_rewards};
-
-use moneymarket::querier::{query_all_balances, query_balance, query_token_balance};
-use terra_cosmwasm::{create_swap_msg, TerraMsgWrapper};
+use crate::state::{
+    read_config, update_global_index, update_total_cumulative_rewards, BLunaAccruedRewardsResponse,
+    Config,
+};
 
 // REWARD_THRESHOLD
 // This value is used as the minimum reward claim amount

--- a/contracts/custody_bluna/src/distribution.rs
+++ b/contracts/custody_bluna/src/distribution.rs
@@ -10,10 +10,7 @@ use moneymarket::querier::{query_all_balances, query_balance, query_token_balanc
 use crate::contract::{CLAIM_REWARDS_OPERATION, SWAP_TO_STABLE_OPERATION};
 use crate::error::ContractError;
 use crate::external::handle::{RewardContractExecuteMsg, RewardContractQueryMsg};
-use crate::state::{
-    read_config, update_global_index, update_total_cumulative_rewards, BLunaAccruedRewardsResponse,
-    Config,
-};
+use crate::state::{read_config, update_rewards_info, BLunaAccruedRewardsResponse, Config};
 
 // REWARD_THRESHOLD
 // This value is used as the minimum reward claim amount
@@ -71,15 +68,12 @@ pub fn distribute_hook(
         contract_addr.clone(),
         config.stable_denom.to_string(),
     )?;
-
     let collateral_amount: Uint256 = query_token_balance(
         deps.as_ref(),
         deps.api.addr_humanize(&config.collateral_token)?,
         contract_addr,
     )?;
-
-    update_global_index(deps.storage, &reward_amount, &collateral_amount)?;
-    update_total_cumulative_rewards(deps.storage, &reward_amount)?;
+    update_rewards_info(deps.storage, &reward_amount, &collateral_amount)?;
 
     Ok(Response::new().add_attributes(vec![
         attr("action", "distribute_rewards"),

--- a/contracts/custody_bluna/src/state.rs
+++ b/contracts/custody_bluna/src/state.rs
@@ -12,8 +12,10 @@ pub struct BLunaAccruedRewardsResponse {
     pub rewards: Uint128,
 }
 
-const KEY_CONFIG: &[u8] = b"config";
 const PREFIX_BORROWER: &[u8] = b"borrower";
+const KEY_CONFIG: &[u8] = b"config";
+const KEY_REWARDS_INFO: &[u8] = b"rewards_info";
+const KEY_USER_REWARDS: &[u8] = b"user_rewards";
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
@@ -31,6 +33,18 @@ pub struct Config {
 pub struct BorrowerInfo {
     pub balance: Uint256,
     pub spendable: Uint256,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
+pub struct RewardsInfo {
+    pub global_index: Decimal256,
+    pub cumulative_total: Uint256,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
+pub struct UserRewards {
+    pub user_index: Decimal256,
+    pub rewards: Uint256,
 }
 
 pub fn store_config(storage: &mut dyn Storage, data: &Config) -> StdResult<()> {
@@ -107,35 +121,25 @@ fn calc_range_start(start_after: Option<CanonicalAddr>) -> Option<Vec<u8>> {
     })
 }
 
-// rewards / collateral
-const KEY_GLOBAL_INDEX: &[u8] = b"global_index";
-const KEY_USER_REWARDS: &[u8] = b"user_rewards";
-const KEY_TOTAL_CUMULATIVE_REWARDS: &[u8] = b"total_cumulative_rewards";
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
-pub struct UserRewards {
-    pub user_index: Decimal256,
-    pub rewards: Uint256,
+pub fn save_rewards_info(storage: &mut dyn Storage, data: &RewardsInfo) -> StdResult<()> {
+    Singleton::new(storage, KEY_REWARDS_INFO).save(data)
 }
 
-pub fn save_global_index(storage: &mut dyn Storage, data: &Decimal256) -> StdResult<()> {
-    Singleton::new(storage, KEY_GLOBAL_INDEX).save(data)
-}
-
-pub fn read_global_index(storage: &dyn Storage) -> Decimal256 {
-    ReadonlySingleton::new(storage, KEY_GLOBAL_INDEX)
+pub fn read_rewards_info(storage: &dyn Storage) -> RewardsInfo {
+    ReadonlySingleton::new(storage, KEY_REWARDS_INFO)
         .load()
-        .unwrap_or_else(|_| Decimal256::zero())
+        .unwrap_or_else(|_| RewardsInfo::default())
 }
 
-pub fn update_global_index(
+pub fn update_rewards_info(
     storage: &mut dyn Storage,
     reward_amount: &Uint256,
     collateral_amount: &Uint256,
 ) -> StdResult<()> {
-    let mut current = read_global_index(storage);
-    current += Decimal256::from_ratio(*reward_amount, *collateral_amount);
-    save_global_index(storage, &current)
+    let mut current = read_rewards_info(storage);
+    current.global_index += Decimal256::from_ratio(*reward_amount, *collateral_amount);
+    current.cumulative_total += *reward_amount;
+    save_rewards_info(storage, &current)
 }
 
 pub fn save_user_rewards(
@@ -153,30 +157,10 @@ pub fn read_user_rewards(storage: &dyn Storage, borrower: &CanonicalAddr) -> Use
 }
 
 pub fn update_user_rewards(storage: &mut dyn Storage, borrower: &CanonicalAddr) -> StdResult<()> {
-    let global_index = read_global_index(storage);
+    let global_index = read_rewards_info(storage).global_index;
     let mut user_rewards = read_user_rewards(storage, borrower);
     let borrower_info = read_borrower_info(storage, borrower);
     user_rewards.rewards += borrower_info.balance * (global_index - user_rewards.user_index);
     user_rewards.user_index = global_index;
     save_user_rewards(storage, borrower, &user_rewards)
-}
-
-pub fn save_total_cumulative_rewards(
-    storage: &mut dyn Storage,
-    new_rewards: &Uint256,
-) -> StdResult<()> {
-    let mut rewards = Singleton::new(storage, KEY_TOTAL_CUMULATIVE_REWARDS);
-    rewards.save(new_rewards)
-}
-
-pub fn read_total_cumulative_rewards(storage: &dyn Storage) -> Uint256 {
-    ReadonlySingleton::new(storage, KEY_TOTAL_CUMULATIVE_REWARDS)
-        .load()
-        .unwrap_or_else(|_| Uint256::zero())
-}
-
-pub fn update_total_cumulative_rewards(storage: &mut dyn Storage, data: &Uint256) -> StdResult<()> {
-    let mut current = read_total_cumulative_rewards(storage);
-    current += *data;
-    save_total_cumulative_rewards(storage, &current)
 }

--- a/contracts/custody_bluna/src/state.rs
+++ b/contracts/custody_bluna/src/state.rs
@@ -1,9 +1,9 @@
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
 use cosmwasm_bignumber::{Decimal256, Uint256};
 use cosmwasm_std::{CanonicalAddr, Deps, Order, StdResult, Storage, Uint128};
 use cosmwasm_storage::{Bucket, ReadonlyBucket, ReadonlySingleton, Singleton};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
 use moneymarket::custody::{BAssetInfo, BorrowerResponse};
 
 //BLunaAccruedRewardsResponse the struct that shows the result of accrued_rewards query

--- a/contracts/custody_bluna/src/state.rs
+++ b/contracts/custody_bluna/src/state.rs
@@ -110,6 +110,7 @@ fn calc_range_start(start_after: Option<CanonicalAddr>) -> Option<Vec<u8>> {
 // rewards / collateral
 const KEY_GLOBAL_INDEX: &[u8] = b"global_index";
 const KEY_USER_REWARDS: &[u8] = b"user_rewards";
+const KEY_TOTAL_CUMULATIVE_REWARDS: &[u8] = b"total_cumulative_rewards";
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
 pub struct UserRewards {
@@ -160,4 +161,24 @@ pub fn update_user_rewards(storage: &mut dyn Storage, borrower: &CanonicalAddr) 
     user_rewards.rewards += borrower_info.balance * (global_index - user_rewards.user_index);
     user_rewards.user_index = global_index;
     save_user_rewards(storage, &borrower, &user_rewards)
+}
+
+pub fn save_total_cumulative_rewards(
+    storage: &mut dyn Storage,
+    new_rewards: &Uint256,
+) -> StdResult<()> {
+    let mut rewards = Singleton::new(storage, KEY_TOTAL_CUMULATIVE_REWARDS);
+    rewards.save(new_rewards)
+}
+
+pub fn read_total_cumulative_rewards(storage: &dyn Storage) -> Uint256 {
+    ReadonlySingleton::new(storage, KEY_TOTAL_CUMULATIVE_REWARDS)
+        .load()
+        .unwrap_or(Uint256::zero())
+}
+
+pub fn update_total_cumulative_rewards(storage: &mut dyn Storage, data: &Uint256) -> StdResult<()> {
+    let mut current = read_total_cumulative_rewards(storage);
+    current += *data;
+    save_total_cumulative_rewards(storage, &current)
 }

--- a/contracts/custody_bluna/src/state.rs
+++ b/contracts/custody_bluna/src/state.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_bignumber::Uint256;
+use cosmwasm_bignumber::{Decimal256, Uint256};
 use cosmwasm_std::{CanonicalAddr, Deps, Order, StdResult, Storage, Uint128};
 use cosmwasm_storage::{Bucket, ReadonlyBucket, ReadonlySingleton, Singleton};
 use moneymarket::custody::{BAssetInfo, BorrowerResponse};
@@ -105,4 +105,59 @@ fn calc_range_start(start_after: Option<CanonicalAddr>) -> Option<Vec<u8>> {
         v.push(1);
         v
     })
+}
+
+// rewards / collateral
+const KEY_GLOBAL_INDEX: &[u8] = b"global_index";
+const KEY_USER_REWARDS: &[u8] = b"user_rewards";
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
+pub struct UserRewards {
+    pub user_index: Decimal256,
+    pub rewards: Uint256,
+}
+
+pub fn save_global_index(storage: &mut dyn Storage, data: &Decimal256) -> StdResult<()> {
+    Singleton::new(storage, KEY_GLOBAL_INDEX).save(data)
+}
+
+pub fn read_global_index(storage: &dyn Storage) -> Decimal256 {
+    ReadonlySingleton::new(storage, KEY_GLOBAL_INDEX)
+        .load()
+        .unwrap_or(Decimal256::zero())
+}
+
+pub fn update_global_index(
+    storage: &mut dyn Storage,
+    reward_amount: &Uint256,
+    collateral_amount: &Uint256,
+) -> StdResult<()> {
+    let mut current = read_global_index(storage);
+    current += Decimal256::from_ratio(*reward_amount, *collateral_amount);
+    save_global_index(storage, &current)
+}
+
+pub fn save_user_rewards(
+    storage: &mut dyn Storage,
+    borrower: &CanonicalAddr,
+    new_rewards: &UserRewards,
+) -> StdResult<()> {
+    let mut user_index_bucket = Bucket::new(storage, KEY_USER_REWARDS);
+    user_index_bucket.save(&borrower, new_rewards)
+}
+
+pub fn read_user_rewards(storage: &dyn Storage, borrower: &CanonicalAddr) -> UserRewards {
+    let user_index_bucket = ReadonlyBucket::new(storage, KEY_USER_REWARDS);
+    user_index_bucket
+        .load(&borrower)
+        .unwrap_or(UserRewards::default())
+}
+
+pub fn update_user_rewards(storage: &mut dyn Storage, borrower: &CanonicalAddr) -> StdResult<()> {
+    let global_index = read_global_index(storage);
+    let mut user_rewards = read_user_rewards(storage, &borrower);
+    let borrower_info = read_borrower_info(storage, &borrower);
+    user_rewards.rewards += borrower_info.balance * (global_index - user_rewards.user_index);
+    user_rewards.user_index = global_index;
+    save_user_rewards(storage, &borrower, &user_rewards)
 }

--- a/contracts/custody_bluna/src/state.rs
+++ b/contracts/custody_bluna/src/state.rs
@@ -125,7 +125,7 @@ pub fn save_global_index(storage: &mut dyn Storage, data: &Decimal256) -> StdRes
 pub fn read_global_index(storage: &dyn Storage) -> Decimal256 {
     ReadonlySingleton::new(storage, KEY_GLOBAL_INDEX)
         .load()
-        .unwrap_or(Decimal256::zero())
+        .unwrap_or_else(|_| Decimal256::zero())
 }
 
 pub fn update_global_index(
@@ -144,23 +144,21 @@ pub fn save_user_rewards(
     new_rewards: &UserRewards,
 ) -> StdResult<()> {
     let mut user_index_bucket = Bucket::new(storage, KEY_USER_REWARDS);
-    user_index_bucket.save(&borrower, new_rewards)
+    user_index_bucket.save(borrower, new_rewards)
 }
 
 pub fn read_user_rewards(storage: &dyn Storage, borrower: &CanonicalAddr) -> UserRewards {
     let user_index_bucket = ReadonlyBucket::new(storage, KEY_USER_REWARDS);
-    user_index_bucket
-        .load(&borrower)
-        .unwrap_or(UserRewards::default())
+    user_index_bucket.load(borrower).unwrap_or_default()
 }
 
 pub fn update_user_rewards(storage: &mut dyn Storage, borrower: &CanonicalAddr) -> StdResult<()> {
     let global_index = read_global_index(storage);
-    let mut user_rewards = read_user_rewards(storage, &borrower);
-    let borrower_info = read_borrower_info(storage, &borrower);
+    let mut user_rewards = read_user_rewards(storage, borrower);
+    let borrower_info = read_borrower_info(storage, borrower);
     user_rewards.rewards += borrower_info.balance * (global_index - user_rewards.user_index);
     user_rewards.user_index = global_index;
-    save_user_rewards(storage, &borrower, &user_rewards)
+    save_user_rewards(storage, borrower, &user_rewards)
 }
 
 pub fn save_total_cumulative_rewards(
@@ -174,7 +172,7 @@ pub fn save_total_cumulative_rewards(
 pub fn read_total_cumulative_rewards(storage: &dyn Storage) -> Uint256 {
     ReadonlySingleton::new(storage, KEY_TOTAL_CUMULATIVE_REWARDS)
         .load()
-        .unwrap_or(Uint256::zero())
+        .unwrap_or_else(|_| Uint256::zero())
 }
 
 pub fn update_total_cumulative_rewards(storage: &mut dyn Storage, data: &Uint256) -> StdResult<()> {

--- a/contracts/custody_bluna/src/testing/mock_querier.rs
+++ b/contracts/custody_bluna/src/testing/mock_querier.rs
@@ -7,7 +7,7 @@ use cosmwasm_std::{
     SystemResult, Uint128, WasmQuery,
 };
 use cosmwasm_storage::to_length_prefixed;
-use cw20::TokenInfoResponse;
+use cw20::{BalanceResponse as Cw20BalanceResponse, Cw20QueryMsg, TokenInfoResponse};
 use std::collections::HashMap;
 use terra_cosmwasm::{TaxCapResponse, TaxRateResponse, TerraQuery, TerraQueryWrapper, TerraRoute};
 
@@ -197,16 +197,40 @@ impl WasmMockQuerier {
                     panic!("DO NOT ENTER HERE")
                 }
             }
-            QueryRequest::Wasm(WasmQuery::Smart {
-                contract_addr: _,
-                msg,
-            }) => match from_binary(msg).unwrap() {
-                RewardContractQueryMsg::AccruedRewards { address: _ } => SystemResult::Ok(
-                    ContractResult::from(to_binary(&BLunaAccruedRewardsResponse {
-                        rewards: self.accrued_rewards.rewards,
-                    })),
-                ),
-            },
+            QueryRequest::Wasm(WasmQuery::Smart { contract_addr, msg })
+                if contract_addr == "reward" =>
+            {
+                match from_binary(msg).unwrap() {
+                    RewardContractQueryMsg::AccruedRewards { address: _ } => SystemResult::Ok(
+                        ContractResult::from(to_binary(&BLunaAccruedRewardsResponse {
+                            rewards: self.accrued_rewards.rewards,
+                        })),
+                    ),
+                }
+            }
+            QueryRequest::Wasm(WasmQuery::Smart { contract_addr, msg }) => {
+                match from_binary(msg).unwrap() {
+                    Cw20QueryMsg::Balance {
+                        address: token_addr,
+                    } => {
+                        let balance = match self.token_querier.balances.get(contract_addr) {
+                            Some(map) if map.contains_key(&token_addr) => {
+                                *map.get(&token_addr).unwrap()
+                            }
+                            _ => {
+                                return SystemResult::Err(SystemError::InvalidRequest {
+                                    error: "Balance not found".to_string(),
+                                    request: msg.as_slice().into(),
+                                })
+                            }
+                        };
+                        SystemResult::Ok(ContractResult::from(to_binary(&Cw20BalanceResponse {
+                            balance,
+                        })))
+                    }
+                    _ => unimplemented!(),
+                }
+            }
             QueryRequest::Bank(BankQuery::Balance { address, denom }) => {
                 if address == "reward" && denom == "uusd" {
                     let bank_res = BalanceResponse {

--- a/contracts/custody_bluna/src/testing/mock_querier.rs
+++ b/contracts/custody_bluna/src/testing/mock_querier.rs
@@ -1,5 +1,5 @@
-use crate::external::handle::RewardContractQueryMsg;
-use crate::state::BLunaAccruedRewardsResponse;
+use std::collections::HashMap;
+
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
     from_binary, from_slice, to_binary, Addr, Api, BalanceResponse, BankQuery, CanonicalAddr, Coin,
@@ -8,8 +8,10 @@ use cosmwasm_std::{
 };
 use cosmwasm_storage::to_length_prefixed;
 use cw20::{BalanceResponse as Cw20BalanceResponse, Cw20QueryMsg, TokenInfoResponse};
-use std::collections::HashMap;
 use terra_cosmwasm::{TaxCapResponse, TaxRateResponse, TerraQuery, TerraQueryWrapper, TerraRoute};
+
+use crate::external::handle::RewardContractQueryMsg;
+use crate::state::BLunaAccruedRewardsResponse;
 
 /// mock_dependencies is a drop-in replacement for cosmwasm_std::testing::mock_dependencies
 /// this uses our CustomQuerier.

--- a/contracts/custody_bluna/src/testing/tests.rs
+++ b/contracts/custody_bluna/src/testing/tests.rs
@@ -1,24 +1,27 @@
 use cosmwasm_bignumber::{Decimal256, Uint256};
+use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
     attr, from_binary, to_binary, Api, Attribute, BankMsg, Coin, ContractResult, CosmosMsg,
     Decimal, Reply, Response, SubMsg, SubMsgExecutionResponse, Uint128, WasmMsg,
 };
+use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
+use terra_cosmwasm::create_swap_msg;
+
+use moneymarket::custody::{
+    BAssetInfo, BorrowerResponse, ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg,
+};
+use moneymarket::liquidation::Cw20HookMsg as LiquidationCw20HookMsg;
 
 use crate::contract::{
     execute, instantiate, query, reply, CLAIM_REWARDS_OPERATION, SWAP_TO_STABLE_OPERATION,
 };
 use crate::error::ContractError;
 use crate::external::handle::RewardContractExecuteMsg;
-use crate::state::{read_borrower_info, read_global_index, read_total_cumulative_rewards, read_user_rewards, save_user_rewards, BLunaAccruedRewardsResponse, UserRewards, save_global_index};
-use crate::testing::mock_querier::mock_dependencies;
-
-use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
-use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
-use moneymarket::custody::{
-    BAssetInfo, BorrowerResponse, ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg,
+use crate::state::{
+    read_borrower_info, read_global_index, read_total_cumulative_rewards, read_user_rewards,
+    save_global_index, save_user_rewards, BLunaAccruedRewardsResponse, UserRewards,
 };
-use moneymarket::liquidation::Cw20HookMsg as LiquidationCw20HookMsg;
-use terra_cosmwasm::create_swap_msg;
+use crate::testing::mock_querier::mock_dependencies;
 
 #[test]
 fn proper_initialization() {

--- a/contracts/custody_bluna/src/testing/tests.rs
+++ b/contracts/custody_bluna/src/testing/tests.rs
@@ -18,8 +18,8 @@ use crate::contract::{
 use crate::error::ContractError;
 use crate::external::handle::RewardContractExecuteMsg;
 use crate::state::{
-    read_borrower_info, read_global_index, read_total_cumulative_rewards, read_user_rewards,
-    save_global_index, save_user_rewards, BLunaAccruedRewardsResponse, UserRewards,
+    read_borrower_info, read_rewards_info, read_user_rewards, save_rewards_info, save_user_rewards,
+    BLunaAccruedRewardsResponse, RewardsInfo, UserRewards,
 };
 use crate::testing::mock_querier::mock_dependencies;
 
@@ -666,15 +666,10 @@ fn distribute_hook() {
         ]
     );
 
-    assert_eq!(
-        read_global_index(&deps.storage).to_string(),
-        "1000".to_string()
-    );
+    let rewards_info = read_rewards_info(&deps.storage);
+    assert_eq!(rewards_info.global_index.to_string(), "1000".to_string());
 
-    assert_eq!(
-        read_total_cumulative_rewards(&deps.storage),
-        Uint256::from(1000000u128)
-    );
+    assert_eq!(rewards_info.cumulative_total, Uint256::from(1000000u128));
 }
 
 #[test]
@@ -725,15 +720,10 @@ fn distribution_hook_zero_rewards() {
 
     assert_eq!(res.messages, vec![],);
 
-    assert_eq!(
-        read_global_index(&deps.storage).to_string(),
-        "0".to_string()
-    );
+    let rewards_info = read_rewards_info(&deps.storage);
+    assert_eq!(rewards_info.global_index.to_string(), "0".to_string());
 
-    assert_eq!(
-        read_total_cumulative_rewards(&deps.storage),
-        Uint256::zero()
-    );
+    assert_eq!(rewards_info.cumulative_total, Uint256::zero());
 }
 
 #[test]
@@ -755,7 +745,14 @@ fn withdraws_staking_rewards() {
             decimals: 6,
         },
     };
-    save_global_index(&mut deps.storage, &Decimal256::from_uint256(999u128)).unwrap();
+    save_rewards_info(
+        &mut deps.storage,
+        &RewardsInfo {
+            global_index: Decimal256::from_uint256(999u128),
+            cumulative_total: Uint256::default(),
+        },
+    )
+    .unwrap();
 
     let info = mock_info(ADDR, &[]);
     let _ = instantiate(deps.as_mut(), mock_env(), info.clone(), msg).unwrap();

--- a/contracts/custody_bluna/src/testing/tests.rs
+++ b/contracts/custody_bluna/src/testing/tests.rs
@@ -9,7 +9,7 @@ use crate::contract::{
 };
 use crate::error::ContractError;
 use crate::external::handle::RewardContractExecuteMsg;
-use crate::state::{read_borrower_info, read_global_index, read_user_rewards, save_user_rewards, BLunaAccruedRewardsResponse, UserRewards, save_global_index};
+use crate::state::{read_borrower_info, read_global_index, read_total_cumulative_rewards, read_user_rewards, save_user_rewards, BLunaAccruedRewardsResponse, UserRewards, save_global_index};
 use crate::testing::mock_querier::mock_dependencies;
 
 use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
@@ -667,6 +667,11 @@ fn distribute_hook() {
         read_global_index(&deps.storage).to_string(),
         "1000".to_string()
     );
+
+    assert_eq!(
+        read_total_cumulative_rewards(&deps.storage),
+        Uint256::from(1000000u128)
+    );
 }
 
 #[test]
@@ -721,6 +726,12 @@ fn distribution_hook_zero_rewards() {
         read_global_index(&deps.storage).to_string(),
         "0".to_string()
     );
+
+    assert_eq!(
+        read_total_cumulative_rewards(&deps.storage),
+        Uint256::zero()
+    );
+}
 
 #[test]
 fn withdraws_staking_rewards() {

--- a/contracts/custody_bluna/src/testing/tests.rs
+++ b/contracts/custody_bluna/src/testing/tests.rs
@@ -647,7 +647,7 @@ fn distribute_hook() {
     // mimic last swap_msg callback to execute distribute_hook
     deps.querier.set_other_balances(Uint128::new(1000000));
     let reply_msg = Reply {
-        id: 2,
+        id: SWAP_TO_STABLE_OPERATION,
         result: ContractResult::Ok(SubMsgExecutionResponse {
             events: vec![],
             data: None,
@@ -704,7 +704,7 @@ fn distribution_hook_zero_rewards() {
 
     // mimic last swap_msg callback to execute distribute_hook
     let reply_msg = Reply {
-        id: 2,
+        id: SWAP_TO_STABLE_OPERATION,
         result: ContractResult::Ok(SubMsgExecutionResponse {
             events: vec![],
             data: None,
@@ -834,7 +834,7 @@ fn swap_to_stable_denom() {
 
     // mimic callback from distribute_rewards to execute swap_to_stable_denom
     let reply_msg = Reply {
-        id: 1,
+        id: CLAIM_REWARDS_OPERATION,
         result: ContractResult::Ok(SubMsgExecutionResponse {
             events: vec![],
             data: None,

--- a/contracts/custody_bluna/src/testing/tests.rs
+++ b/contracts/custody_bluna/src/testing/tests.rs
@@ -666,10 +666,13 @@ fn distribute_hook() {
         ]
     );
 
-    let rewards_info = read_rewards_info(&deps.storage);
-    assert_eq!(rewards_info.global_index.to_string(), "1000".to_string());
-
-    assert_eq!(rewards_info.cumulative_total, Uint256::from(1000000u128));
+    assert_eq!(
+        read_rewards_info(&deps.storage).unwrap(),
+        RewardsInfo {
+            global_index: Decimal256::from_uint256(1000u128),
+            cumulative_total: Uint256::from(1000000u128),
+        }
+    );
 }
 
 #[test]
@@ -720,10 +723,13 @@ fn distribution_hook_zero_rewards() {
 
     assert_eq!(res.messages, vec![],);
 
-    let rewards_info = read_rewards_info(&deps.storage);
-    assert_eq!(rewards_info.global_index.to_string(), "0".to_string());
-
-    assert_eq!(rewards_info.cumulative_total, Uint256::zero());
+    assert_eq!(
+        read_rewards_info(&deps.storage).unwrap(),
+        RewardsInfo {
+            global_index: Decimal256::zero(),
+            cumulative_total: Uint256::zero(),
+        }
+    );
 }
 
 #[test]
@@ -767,7 +773,7 @@ fn withdraws_staking_rewards() {
     );
 
     assert_eq!(
-        read_user_rewards(&deps.storage, &deps.api.addr_canonicalize(ADDR).unwrap()),
+        read_user_rewards(&deps.storage, &deps.api.addr_canonicalize(ADDR).unwrap()).unwrap(),
         UserRewards {
             user_index: Decimal256::zero(),
             rewards: Uint256::from(1000000u128),
@@ -778,7 +784,7 @@ fn withdraws_staking_rewards() {
     let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     assert_eq!(
-        read_user_rewards(&deps.storage, &deps.api.addr_canonicalize(ADDR).unwrap()),
+        read_user_rewards(&deps.storage, &deps.api.addr_canonicalize(ADDR).unwrap()).unwrap(),
         UserRewards {
             user_index: Decimal256::from_uint256(999u128),
             rewards: Uint256::zero(),

--- a/contracts/overseer/src/collateral.rs
+++ b/contracts/overseer/src/collateral.rs
@@ -51,7 +51,7 @@ pub fn lock_collateral(
     // Logging stuff, so can be removed
     let collateral_logs: Vec<String> = collaterals_human
         .iter()
-        .map(|c| format!("{}{}", c.1, c.0.to_string()))
+        .map(|c| format!("{}{}", c.1, c.0))
         .collect();
 
     Ok(Response::new().add_messages(messages).add_attributes(vec![
@@ -95,7 +95,7 @@ pub fn unlock_collateral(
     store_collaterals(deps.storage, &borrower_raw, &cur_collaterals)?;
 
     let mut messages: Vec<SubMsg> = vec![];
-    for collateral in collaterals.clone() {
+    for collateral in collaterals {
         let whitelist_elem: WhitelistElem = read_whitelist_elem(deps.storage, &collateral.0)?;
         messages.push(SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: deps
@@ -113,7 +113,7 @@ pub fn unlock_collateral(
     // Logging stuff, so can be removed
     let collateral_logs: Vec<String> = collaterals_human
         .iter()
-        .map(|c| format!("{}{}", c.1, c.0.to_string()))
+        .map(|c| format!("{}{}", c.1, c.0))
         .collect();
 
     Ok(Response::new()

--- a/packages/moneymarket/src/custody.rs
+++ b/packages/moneymarket/src/custody.rs
@@ -93,6 +93,7 @@ pub enum QueryMsg {
         start_after: Option<String>,
         limit: Option<u32>,
     },
+    TotalCumulativeRewards {},
 }
 
 // We define a custom struct for each query response

--- a/packages/moneymarket/src/custody.rs
+++ b/packages/moneymarket/src/custody.rs
@@ -41,15 +41,9 @@ pub enum ExecuteMsg {
         liquidation_contract: Option<String>,
     },
     /// Make specified amount of tokens unspendable
-    LockCollateral {
-        borrower: String,
-        amount: Uint256,
-    },
+    LockCollateral { borrower: String, amount: Uint256 },
     /// Make specified amount of collateral tokens spendable
-    UnlockCollateral {
-        borrower: String,
-        amount: Uint256,
-    },
+    UnlockCollateral { borrower: String, amount: Uint256 },
     /// Claim bAsset rewards and distribute claimed rewards
     /// to market and overseer contracts
     DistributeRewards {},
@@ -68,9 +62,7 @@ pub enum ExecuteMsg {
     /// Withdraw spendable collateral token.
     /// If the amount is not given,
     /// return all spendable collateral
-    WithdrawCollateral {
-        amount: Option<Uint256>,
-    },
+    WithdrawCollateral { amount: Option<Uint256> },
     /// Withdraw accrued staking rewards.
     WithdrawStakingRewards {},
 }

--- a/packages/moneymarket/src/custody.rs
+++ b/packages/moneymarket/src/custody.rs
@@ -41,9 +41,15 @@ pub enum ExecuteMsg {
         liquidation_contract: Option<String>,
     },
     /// Make specified amount of tokens unspendable
-    LockCollateral { borrower: String, amount: Uint256 },
+    LockCollateral {
+        borrower: String,
+        amount: Uint256,
+    },
     /// Make specified amount of collateral tokens spendable
-    UnlockCollateral { borrower: String, amount: Uint256 },
+    UnlockCollateral {
+        borrower: String,
+        amount: Uint256,
+    },
     /// Claim bAsset rewards and distribute claimed rewards
     /// to market and overseer contracts
     DistributeRewards {},
@@ -62,7 +68,11 @@ pub enum ExecuteMsg {
     /// Withdraw spendable collateral token.
     /// If the amount is not given,
     /// return all spendable collateral
-    WithdrawCollateral { amount: Option<Uint256> },
+    WithdrawCollateral {
+        amount: Option<Uint256>,
+    },
+    /// Withdraw accrued staking rewards.
+    WithdrawStakingRewards {},
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/moneymarket/src/custody.rs
+++ b/packages/moneymarket/src/custody.rs
@@ -85,7 +85,7 @@ pub enum QueryMsg {
         start_after: Option<String>,
         limit: Option<u32>,
     },
-    TotalCumulativeRewards {},
+    RewardsInfo {},
 }
 
 // We define a custom struct for each query response

--- a/packages/moneymarket/src/querier.rs
+++ b/packages/moneymarket/src/querier.rs
@@ -52,8 +52,7 @@ pub fn query_supply(deps: Deps, contract_addr: Addr) -> StdResult<Uint256> {
             contract_addr: contract_addr.to_string(),
             msg: to_binary(&Cw20QueryMsg::TokenInfo {})?,
         }))?;
-
-    Ok(Uint256::from(token_info.total_supply))
+    Ok(token_info.total_supply.into())
 }
 
 pub fn query_tax_rate_and_cap(deps: Deps, denom: String) -> StdResult<(Decimal256, Uint256)> {

--- a/packages/moneymarket/src/querier.rs
+++ b/packages/moneymarket/src/querier.rs
@@ -4,9 +4,9 @@ use serde::{Deserialize, Serialize};
 use cosmwasm_bignumber::{Decimal256, Uint256};
 use cosmwasm_std::{
     to_binary, Addr, AllBalanceResponse, BalanceResponse, BankQuery, Coin, Deps, QueryRequest,
-    StdError, StdResult, Uint128, WasmQuery,
+    StdError, StdResult, WasmQuery,
 };
-use cw20::{Cw20QueryMsg, TokenInfoResponse};
+use cw20::{BalanceResponse as Cw20BalanceResponse, Cw20QueryMsg, TokenInfoResponse};
 use terra_cosmwasm::TerraQuerier;
 
 use crate::oracle::{PriceResponse, QueryMsg as OracleQueryMsg};
@@ -35,18 +35,14 @@ pub fn query_token_balance(
     contract_addr: Addr,
     account_addr: Addr,
 ) -> StdResult<Uint256> {
-    // load balance form the token contract
-    let balance: Uint128 = deps
-        .querier
-        .query(&QueryRequest::Wasm(WasmQuery::Smart {
-            contract_addr: contract_addr.to_string(),
-            msg: to_binary(&Cw20QueryMsg::Balance {
-                address: account_addr.to_string(),
-            })?,
-        }))
-        .unwrap_or_else(|_| Uint128::zero());
-
-    Ok(balance.into())
+    // load balance from the token contract
+    let res: Cw20BalanceResponse = deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
+        contract_addr: contract_addr.to_string(),
+        msg: to_binary(&Cw20QueryMsg::Balance {
+            address: account_addr.to_string(),
+        })?,
+    }))?;
+    Ok(res.balance.into())
 }
 
 pub fn query_supply(deps: Deps, contract_addr: Addr) -> StdResult<Uint256> {


### PR DESCRIPTION
- Collect staking rewards directly from custody contract
- Track total cumulative rewards
- Use cw-plus-storage

and some minor fixes/tweaks.