### PR TITLE
chore: add migrate hook to custody contracts

### DIFF
--- a/contracts/custody_base/src/contract.rs
+++ b/contracts/custody_base/src/contract.rs
@@ -14,7 +14,9 @@ use crate::state::{read_config, store_config, Config};
 
 use cw20::Cw20ReceiveMsg;
 use moneymarket::common::optional_addr_validate;
-use moneymarket::custody::{ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
+use moneymarket::custody::{
+    ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
+};
 use terra_cosmwasm::TerraMsgWrapper;
 
 pub const CLAIM_REWARDS_OPERATION: u64 = 1u64;
@@ -169,4 +171,9 @@ pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
         stable_denom: config.stable_denom,
         basset_info: config.basset_info,
     })
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
+    Ok(Response::default())
 }

--- a/contracts/custody_beth/schema/cw20_hook_msg.json
+++ b/contracts/custody_beth/schema/cw20_hook_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Cw20HookMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Deposit collateral token",
       "type": "object",

--- a/contracts/custody_beth/schema/execute_msg.json
+++ b/contracts/custody_beth/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "CW20 token receiver",
       "type": "object",

--- a/contracts/custody_beth/schema/query_msg.json
+++ b/contracts/custody_beth/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [

--- a/contracts/custody_beth/src/contract.rs
+++ b/contracts/custody_beth/src/contract.rs
@@ -15,7 +15,9 @@ use crate::state::{read_config, store_config, Config};
 
 use cw20::Cw20ReceiveMsg;
 use moneymarket::common::optional_addr_validate;
-use moneymarket::custody::{ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
+use moneymarket::custody::{
+    ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
+};
 use terra_cosmwasm::TerraMsgWrapper;
 
 pub const CLAIM_REWARDS_OPERATION: u64 = 1u64;
@@ -185,4 +187,9 @@ pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
         stable_denom: config.stable_denom,
         basset_info: config.basset_info,
     })
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
+    Ok(Response::default())
 }

--- a/contracts/custody_bluna/schema/cw20_hook_msg.json
+++ b/contracts/custody_bluna/schema/cw20_hook_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Cw20HookMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Deposit collateral token",
       "type": "object",

--- a/contracts/custody_bluna/schema/execute_msg.json
+++ b/contracts/custody_bluna/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "CW20 token receiver",
       "type": "object",

--- a/contracts/custody_bluna/schema/query_msg.json
+++ b/contracts/custody_bluna/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [

--- a/contracts/custody_bluna/src/contract.rs
+++ b/contracts/custody_bluna/src/contract.rs
@@ -15,7 +15,9 @@ use crate::state::{read_config, store_config, Config};
 
 use cw20::Cw20ReceiveMsg;
 use moneymarket::common::optional_addr_validate;
-use moneymarket::custody::{ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
+use moneymarket::custody::{
+    ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
+};
 use terra_cosmwasm::TerraMsgWrapper;
 
 pub const CLAIM_REWARDS_OPERATION: u64 = 1u64;
@@ -185,4 +187,9 @@ pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
         stable_denom: config.stable_denom,
         basset_info: config.basset_info,
     })
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
+    Ok(Response::default())
 }

--- a/contracts/custody_bluna/src/distribution.rs
+++ b/contracts/custody_bluna/src/distribution.rs
@@ -98,7 +98,7 @@ pub fn swap_to_stable_denom(
 ) -> Result<Response<TerraMsgWrapper>, ContractError> {
     let config: Config = read_config(deps.storage)?;
 
-    let contract_addr = env.contract.address;
+    let contract_addr = env.contract.address.clone();
     let balances: Vec<Coin> = query_all_balances(deps.as_ref(), contract_addr)?;
     let mut messages: Vec<SubMsg<TerraMsgWrapper>> = balances
         .iter()
@@ -109,6 +109,8 @@ pub fn swap_to_stable_denom(
     if let Some(last) = messages.last_mut() {
         last.id = SWAP_TO_STABLE_OPERATION;
         last.reply_on = ReplyOn::Success;
+    } else {
+        return distribute_hook(deps, env);
     }
 
     Ok(Response::new().add_submessages(messages))

--- a/packages/moneymarket/src/custody.rs
+++ b/packages/moneymarket/src/custody.rs
@@ -74,6 +74,10 @@ pub enum Cw20HookMsg {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+pub struct MigrateMsg {}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     Config {},
     Borrower {


### PR DESCRIPTION
## Summary of changes

- Adds a `migrate` hook to the following custody contracts: `base`, `bluna`, `beth`. 
- Adds [bLUNA bug fix from MSNTCS](https://github.com/MSNTCS/money-market-contracts/blob/4b0e52e52e608f8ef3ab6197aafbd3b708389134/contracts/custody_bluna/src/distribution.rs) (see [a8dbd9a](https://github.com/Anchor-Protocol/money-market-contracts/commit/a8dbd9a5df0242f7507381798ca592c095b283d0))

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Added a relevant changelog entry to CHANGELOG.md

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
