### PR TITLE
chore: update dyn rate migrate

### DIFF
--- a/contracts/overseer/schema/config_response.json
+++ b/contracts/overseer/schema/config_response.json
@@ -6,6 +6,11 @@
     "anc_purchase_factor",
     "buffer_distribution_factor",
     "collector_contract",
+    "dyn_rate_epoch",
+    "dyn_rate_max",
+    "dyn_rate_maxchange",
+    "dyn_rate_min",
+    "dyn_rate_yr_increase_expectation",
     "epoch_period",
     "liquidation_contract",
     "market_contract",
@@ -25,6 +30,23 @@
     },
     "collector_contract": {
       "type": "string"
+    },
+    "dyn_rate_epoch": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "dyn_rate_max": {
+      "$ref": "#/definitions/Decimal256"
+    },
+    "dyn_rate_maxchange": {
+      "$ref": "#/definitions/Decimal256"
+    },
+    "dyn_rate_min": {
+      "$ref": "#/definitions/Decimal256"
+    },
+    "dyn_rate_yr_increase_expectation": {
+      "$ref": "#/definitions/Decimal256"
     },
     "epoch_period": {
       "type": "integer",

--- a/contracts/overseer/schema/execute_msg.json
+++ b/contracts/overseer/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Owner operations Update Configs",
       "type": "object",
@@ -23,6 +23,54 @@
               ]
             },
             "buffer_distribution_factor": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Decimal256"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "dyn_rate_epoch": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "dyn_rate_max": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Decimal256"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "dyn_rate_maxchange": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Decimal256"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "dyn_rate_min": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Decimal256"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "dyn_rate_yr_increase_expectation": {
               "anyOf": [
                 {
                   "$ref": "#/definitions/Decimal256"
@@ -286,6 +334,18 @@
               "type": "string"
             }
           }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "fund_reserve"
+      ],
+      "properties": {
+        "fund_reserve": {
+          "type": "object"
         }
       },
       "additionalProperties": false

--- a/contracts/overseer/schema/instantiate_msg.json
+++ b/contracts/overseer/schema/instantiate_msg.json
@@ -6,6 +6,11 @@
     "anc_purchase_factor",
     "buffer_distribution_factor",
     "collector_contract",
+    "dyn_rate_epoch",
+    "dyn_rate_max",
+    "dyn_rate_maxchange",
+    "dyn_rate_min",
+    "dyn_rate_yr_increase_expectation",
     "epoch_period",
     "liquidation_contract",
     "market_contract",
@@ -36,6 +41,39 @@
     "collector_contract": {
       "description": "Collector contract address which is purchasing ANC token",
       "type": "string"
+    },
+    "dyn_rate_epoch": {
+      "title": "of blocks per each dynamic rate change period",
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "dyn_rate_max": {
+      "$ref": "#/definitions/Decimal256"
+    },
+    "dyn_rate_maxchange": {
+      "description": "maximum rate change during update",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Decimal256"
+        }
+      ]
+    },
+    "dyn_rate_min": {
+      "description": "clamps for dyn rate",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Decimal256"
+        }
+      ]
+    },
+    "dyn_rate_yr_increase_expectation": {
+      "description": "amount of slack in yr change to trigger rate update",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Decimal256"
+        }
+      ]
     },
     "epoch_period": {
       "title": "of blocks per epoch period",

--- a/contracts/overseer/schema/query_msg.json
+++ b/contracts/overseer/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [
@@ -21,6 +21,18 @@
       ],
       "properties": {
         "epoch_state": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "dynrate_state"
+      ],
+      "properties": {
+        "dynrate_state": {
           "type": "object"
         }
       },

--- a/contracts/overseer/src/contract.rs
+++ b/contracts/overseer/src/contract.rs
@@ -117,7 +117,7 @@ pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> StdResult<Response> 
         },
     )?;
     let new_rate = max(
-        min(config.threshold_deposit_rate, msg.dyn_rate_max),
+        min(config.threshold_deposit_rate, msg.dyn_rate_current),
         msg.dyn_rate_min,
     );
     config.threshold_deposit_rate = new_rate;

--- a/packages/moneymarket/src/overseer.rs
+++ b/packages/moneymarket/src/overseer.rs
@@ -55,7 +55,7 @@ pub struct MigrateMsg {
     pub dyn_rate_maxchange: Decimal256,
     /// Margin to define expectation of rate increase
     pub dyn_rate_yr_increase_expectation: Decimal256,
-
+    pub dyn_rate_current: Decimal256,
     pub dyn_rate_min: Decimal256,
     pub dyn_rate_max: Decimal256,
 }


### PR DESCRIPTION
## Summary of changes

- adds `dyn_rate_current` to `MigrateMsg`
- generates missing schemas. 

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Added a relevant changelog entry to CHANGELOG.md

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
