### PR TITLE
feat: Repay from yield reserve

### DIFF
--- a/contracts/market/schema/cw20_hook_msg.json
+++ b/contracts/market/schema/cw20_hook_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Cw20HookMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Return stable coins to a user according to exchange rate",
       "type": "object",

--- a/contracts/market/schema/execute_msg.json
+++ b/contracts/market/schema/execute_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [

--- a/contracts/market/schema/query_msg.json
+++ b/contracts/market/schema/query_msg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "anyOf": [
+  "oneOf": [
     {
       "type": "object",
       "required": [

--- a/contracts/market/src/contract.rs
+++ b/contracts/market/src/contract.rs
@@ -88,7 +88,7 @@ pub fn instantiate(
                 admin: None,
                 code_id: msg.aterra_code_id,
                 funds: vec![],
-                label: "".to_string(),
+                label: "aterra".to_string(),
                 msg: to_binary(&TokenInstantiateMsg {
                     name: format!("Anchor Terra {}", msg.stable_denom[1..].to_uppercase()),
                     symbol: format!(

--- a/contracts/market/src/contract.rs
+++ b/contracts/market/src/contract.rs
@@ -159,13 +159,13 @@ pub fn execute(
             target_deposit_rate: _,
             threshold_deposit_rate: _,
             distributed_interest: _,
-        } => Ok(Response::new()),
-        ExecuteMsg::DepositStable {} => Ok(Response::new()),
+        } => Err(ContractError::Deprecated {}),
+        ExecuteMsg::DepositStable {} => Err(ContractError::Deprecated {}),
         ExecuteMsg::BorrowStable {
             borrow_amount: _,
             to: _,
-        } => Ok(Response::new()),
-        ExecuteMsg::RepayStable {} => Ok(Response::new()),
+        } => Err(ContractError::Deprecated {}),
+        ExecuteMsg::RepayStable {} => Err(ContractError::Deprecated {}),
         ExecuteMsg::RepayStableFromLiquidation {
             borrower,
             prev_balance,
@@ -179,7 +179,7 @@ pub fn execute(
                 prev_balance,
             )
         }
-        ExecuteMsg::ClaimRewards { to: _ } => Ok(Response::new()),
+        ExecuteMsg::ClaimRewards { to: _ } => Err(ContractError::Deprecated {}),
     }
 }
 

--- a/contracts/market/src/contract.rs
+++ b/contracts/market/src/contract.rs
@@ -2,10 +2,10 @@
 use cosmwasm_std::entry_point;
 
 use crate::borrow::{
-    borrow_stable, claim_rewards, compute_interest, compute_interest_raw, compute_reward,
-    query_borrower_info, query_borrower_infos, repay_stable, repay_stable_from_liquidation,
+    compute_interest, compute_interest_raw, compute_reward, query_borrower_info,
+    query_borrower_infos, repay_stable_from_liquidation,
 };
-use crate::deposit::{compute_exchange_rate_raw, deposit_stable, redeem_stable};
+use crate::deposit::{compute_exchange_rate_raw, redeem_stable};
 use crate::error::ContractError;
 use crate::querier::{query_borrow_rate, query_target_deposit_rate};
 use crate::response::MsgInstantiateContractResponse;
@@ -155,31 +155,17 @@ pub fn execute(
             )
         }
         ExecuteMsg::ExecuteEpochOperations {
-            deposit_rate,
-            target_deposit_rate,
-            threshold_deposit_rate,
-            distributed_interest,
-        } => execute_epoch_operations(
-            deps,
-            env,
-            info,
-            deposit_rate,
-            target_deposit_rate,
-            threshold_deposit_rate,
-            distributed_interest,
-        ),
-        ExecuteMsg::DepositStable {} => deposit_stable(deps, env, info),
-        ExecuteMsg::BorrowStable { borrow_amount, to } => {
-            let api = deps.api;
-            borrow_stable(
-                deps,
-                env,
-                info,
-                borrow_amount,
-                optional_addr_validate(api, to)?,
-            )
-        }
-        ExecuteMsg::RepayStable {} => repay_stable(deps, env, info),
+            deposit_rate: _,
+            target_deposit_rate: _,
+            threshold_deposit_rate: _,
+            distributed_interest: _,
+        } => Ok(Response::new()),
+        ExecuteMsg::DepositStable {} => Ok(Response::new()),
+        ExecuteMsg::BorrowStable {
+            borrow_amount: _,
+            to: _,
+        } => Ok(Response::new()),
+        ExecuteMsg::RepayStable {} => Ok(Response::new()),
         ExecuteMsg::RepayStableFromLiquidation {
             borrower,
             prev_balance,
@@ -193,10 +179,7 @@ pub fn execute(
                 prev_balance,
             )
         }
-        ExecuteMsg::ClaimRewards { to } => {
-            let api = deps.api;
-            claim_rewards(deps, env, info, optional_addr_validate(api, to)?)
-        }
+        ExecuteMsg::ClaimRewards { to: _ } => Ok(Response::new()),
     }
 }
 

--- a/contracts/market/src/error.rs
+++ b/contracts/market/src/error.rs
@@ -35,4 +35,7 @@ pub enum ContractError {
 
     #[error("Repay amount must be greater than 0 {0}")]
     ZeroRepay(String),
+
+    #[error("Functionality deprecated")]
+    Deprecated {},
 }

--- a/contracts/market/src/testing/deposit_ut.rs
+++ b/contracts/market/src/testing/deposit_ut.rs
@@ -6,6 +6,7 @@ use cosmwasm_std::testing::{mock_env, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{Api, Coin, Uint128};
 
 #[test]
+#[ignore = "deprecated functionality"]
 fn proper_compute_exchange_rate() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),

--- a/contracts/market/src/testing/tests.rs
+++ b/contracts/market/src/testing/tests.rs
@@ -1,3 +1,4 @@
+use crate::borrow::borrow_stable as _borrow_stable;
 use crate::contract::{execute, instantiate, query, reply, INITIAL_DEPOSIT_AMOUNT};
 use crate::error::ContractError;
 use crate::response::MsgInstantiateContractResponse;
@@ -243,6 +244,7 @@ fn update_config() {
 }
 
 #[test]
+#[ignore = "deprecated functionality"]
 fn deposit_stable_huge_amount() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),
@@ -399,6 +401,7 @@ fn deposit_stable_huge_amount() {
 }
 
 #[test]
+#[ignore = "deprecated functionality"]
 fn deposit_stable() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),
@@ -714,7 +717,25 @@ fn redeem_stable() {
         }],
     );
 
+    // deposit stable is no-ops
     let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+    // set prev_aterra_supply to `deposit amount` i.e: simulate deposit stable
+    store_state(
+        deps.as_mut().storage,
+        &State {
+            total_liabilities: Decimal256::zero(),
+            total_reserves: Decimal256::zero(),
+            last_interest_updated: mock_env().block.height,
+            last_reward_updated: mock_env().block.height,
+            global_interest_index: Decimal256::one(),
+            global_reward_index: Decimal256::zero(),
+            anc_emission_rate: Decimal256::one(),
+            prev_aterra_supply: Uint256::from(Uint128::from(1000000u128)),
+            prev_exchange_rate: Decimal256::one(),
+        },
+    )
+    .unwrap();
 
     deps.querier.with_token_balances(&[(
         &"at-uusd".to_string(),
@@ -830,6 +851,7 @@ fn redeem_stable() {
 }
 
 #[test]
+#[ignore = "deprecated functionality"]
 fn borrow_stable() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),
@@ -1075,6 +1097,7 @@ fn borrow_stable() {
 }
 
 #[test]
+#[ignore = "deprecated functionality"]
 fn assert_max_borrow_factor() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),
@@ -1185,6 +1208,7 @@ fn assert_max_borrow_factor() {
 }
 
 #[test]
+#[ignore = "deprecated functionality"]
 fn repay_stable() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),
@@ -1442,6 +1466,7 @@ fn repay_stable_from_liquidation() {
     )
     .unwrap();
 
+    // borrow stable is no-ops
     let msg = ExecuteMsg::BorrowStable {
         borrow_amount: Uint256::from(500000u64),
         to: None,
@@ -1449,6 +1474,16 @@ fn repay_stable_from_liquidation() {
 
     env.block.height += 100;
     let _res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+
+    // simulate borrow stable
+    _borrow_stable(
+        deps.as_mut(),
+        env.clone(),
+        info.clone(),
+        Uint256::from(500000u64),
+        Some(Addr::unchecked("")),
+    )
+    .unwrap();
 
     // update balance to make repay
     deps.querier.update_balance(
@@ -1539,6 +1574,7 @@ fn repay_stable_from_liquidation() {
 }
 
 #[test]
+#[ignore = "deprecated functionality"]
 fn claim_rewards() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),
@@ -1670,6 +1706,7 @@ fn claim_rewards() {
 }
 
 #[test]
+#[ignore = "deprecated functionality"]
 fn execute_epoch_operations() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),

--- a/contracts/market/src/testing/tests.rs
+++ b/contracts/market/src/testing/tests.rs
@@ -693,16 +693,6 @@ fn redeem_stable() {
     let info = mock_info("addr0000", &[]);
     let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
-    // Deposit 1000000
-    let msg = ExecuteMsg::DepositStable {};
-    let info = mock_info(
-        "addr0000",
-        &[Coin {
-            denom: "uusd".to_string(),
-            amount: Uint128::from(1000000u128),
-        }],
-    );
-
     deps.querier
         .with_borrow_rate(&[(&"interest".to_string(), &Decimal256::percent(1))]);
     deps.querier.with_token_balances(&[(
@@ -716,9 +706,6 @@ fn redeem_stable() {
             amount: Uint128::from(INITIAL_DEPOSIT_AMOUNT + 1000000u128),
         }],
     );
-
-    // deposit stable is no-ops
-    let _res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
     // set prev_aterra_supply to `deposit amount` i.e: simulate deposit stable
     store_state(
@@ -1441,7 +1428,7 @@ fn repay_stable_from_liquidation() {
         collector_contract: "collector".to_string(),
         distributor_contract: "distributor".to_string(),
     };
-    let mut env = mock_env();
+    let env = mock_env();
     let info = mock_info("addr0000", &[]);
     let _res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
 
@@ -1465,15 +1452,6 @@ fn repay_stable_from_liquidation() {
         },
     )
     .unwrap();
-
-    // borrow stable is no-ops
-    let msg = ExecuteMsg::BorrowStable {
-        borrow_amount: Uint256::from(500000u64),
-        to: None,
-    };
-
-    env.block.height += 100;
-    let _res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
 
     // simulate borrow stable
     _borrow_stable(

--- a/contracts/market/src/testing/tests.rs
+++ b/contracts/market/src/testing/tests.rs
@@ -54,7 +54,7 @@ fn proper_initialization() {
                 admin: None,
                 code_id: 123u64,
                 funds: vec![],
-                label: "".to_string(),
+                label: "aterra".to_string(),
                 msg: to_binary(&TokenInstantiateMsg {
                     name: "Anchor Terra USD".to_string(),
                     symbol: "aUST".to_string(),

--- a/contracts/market/src/testing/tests.rs
+++ b/contracts/market/src/testing/tests.rs
@@ -1,5 +1,5 @@
-use crate::borrow::borrow_stable as _borrow_stable;
 use crate::contract::{execute, instantiate, query, reply, INITIAL_DEPOSIT_AMOUNT};
+use crate::borrow::{borrow_stable as _borrow_stable};
 use crate::error::ContractError;
 use crate::response::MsgInstantiateContractResponse;
 use crate::state::{read_borrower_infos, read_state, store_state, State};
@@ -243,8 +243,7 @@ fn update_config() {
     }
 }
 
-#[test]
-#[ignore = "deprecated functionality"]
+#[test] #[ignore = "deprecated functionality"]
 fn deposit_stable_huge_amount() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),
@@ -400,8 +399,7 @@ fn deposit_stable_huge_amount() {
     );
 }
 
-#[test]
-#[ignore = "deprecated functionality"]
+#[test] #[ignore = "deprecated functionality"]
 fn deposit_stable() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),
@@ -850,8 +848,7 @@ fn redeem_stable() {
     );
 }
 
-#[test]
-#[ignore = "deprecated functionality"]
+#[test] #[ignore = "deprecated functionality"]
 fn borrow_stable() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),
@@ -1096,8 +1093,7 @@ fn borrow_stable() {
     }
 }
 
-#[test]
-#[ignore = "deprecated functionality"]
+#[test] #[ignore = "deprecated functionality"]
 fn assert_max_borrow_factor() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),
@@ -1207,8 +1203,7 @@ fn assert_max_borrow_factor() {
     }
 }
 
-#[test]
-#[ignore = "deprecated functionality"]
+#[test] #[ignore = "deprecated functionality"]
 fn repay_stable() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),
@@ -1477,13 +1472,12 @@ fn repay_stable_from_liquidation() {
 
     // simulate borrow stable
     _borrow_stable(
-        deps.as_mut(),
-        env.clone(),
-        info.clone(),
-        Uint256::from(500000u64),
-        Some(Addr::unchecked("")),
-    )
-    .unwrap();
+        deps.as_mut(), 
+        env.clone(), 
+        info.clone(), 
+        Uint256::from(500000u64), 
+        Some(Addr::unchecked(""))
+    ).unwrap();
 
     // update balance to make repay
     deps.querier.update_balance(
@@ -1573,8 +1567,7 @@ fn repay_stable_from_liquidation() {
     );
 }
 
-#[test]
-#[ignore = "deprecated functionality"]
+#[test] #[ignore = "deprecated functionality"]
 fn claim_rewards() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),
@@ -1705,8 +1698,7 @@ fn claim_rewards() {
     );
 }
 
-#[test]
-#[ignore = "deprecated functionality"]
+#[test] #[ignore = "deprecated functionality"]
 fn execute_epoch_operations() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),

--- a/contracts/market/src/testing/tests.rs
+++ b/contracts/market/src/testing/tests.rs
@@ -1,5 +1,5 @@
+use crate::borrow::borrow_stable as _borrow_stable;
 use crate::contract::{execute, instantiate, query, reply, INITIAL_DEPOSIT_AMOUNT};
-use crate::borrow::{borrow_stable as _borrow_stable};
 use crate::error::ContractError;
 use crate::response::MsgInstantiateContractResponse;
 use crate::state::{read_borrower_infos, read_state, store_state, State};
@@ -243,7 +243,8 @@ fn update_config() {
     }
 }
 
-#[test] #[ignore = "deprecated functionality"]
+#[test]
+#[ignore = "deprecated functionality"]
 fn deposit_stable_huge_amount() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),
@@ -399,7 +400,8 @@ fn deposit_stable_huge_amount() {
     );
 }
 
-#[test] #[ignore = "deprecated functionality"]
+#[test]
+#[ignore = "deprecated functionality"]
 fn deposit_stable() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),
@@ -848,7 +850,8 @@ fn redeem_stable() {
     );
 }
 
-#[test] #[ignore = "deprecated functionality"]
+#[test]
+#[ignore = "deprecated functionality"]
 fn borrow_stable() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),
@@ -1093,7 +1096,8 @@ fn borrow_stable() {
     }
 }
 
-#[test] #[ignore = "deprecated functionality"]
+#[test]
+#[ignore = "deprecated functionality"]
 fn assert_max_borrow_factor() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),
@@ -1203,7 +1207,8 @@ fn assert_max_borrow_factor() {
     }
 }
 
-#[test] #[ignore = "deprecated functionality"]
+#[test]
+#[ignore = "deprecated functionality"]
 fn repay_stable() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),
@@ -1472,12 +1477,13 @@ fn repay_stable_from_liquidation() {
 
     // simulate borrow stable
     _borrow_stable(
-        deps.as_mut(), 
-        env.clone(), 
-        info.clone(), 
-        Uint256::from(500000u64), 
-        Some(Addr::unchecked(""))
-    ).unwrap();
+        deps.as_mut(),
+        env.clone(),
+        info.clone(),
+        Uint256::from(500000u64),
+        Some(Addr::unchecked("")),
+    )
+    .unwrap();
 
     // update balance to make repay
     deps.querier.update_balance(
@@ -1567,7 +1573,8 @@ fn repay_stable_from_liquidation() {
     );
 }
 
-#[test] #[ignore = "deprecated functionality"]
+#[test]
+#[ignore = "deprecated functionality"]
 fn claim_rewards() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),
@@ -1698,7 +1705,8 @@ fn claim_rewards() {
     );
 }
 
-#[test] #[ignore = "deprecated functionality"]
+#[test]
+#[ignore = "deprecated functionality"]
 fn execute_epoch_operations() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),

--- a/contracts/overseer/Cargo.toml
+++ b/contracts/overseer/Cargo.toml
@@ -46,6 +46,16 @@ thiserror = "1.0.2"
 cosmwasm-schema = "0.16.0"
 cw20 = "0.8.0"
 terra-cosmwasm = "2.2.0"
+terra-multi-test = { git = "https://github.com/astroport-fi/terra-plus.git", tag = "v0.9.1-terra" }
+cw20-base = { version = "0.8", features = ["library"] }
+moneymarket-market-old = { git = "https://github.com/Anchor-Protocol/money-market-contracts.git", branch = "dev/vUST" }
+moneymarket-overseer-old = { git = "https://github.com/Anchor-Protocol/money-market-contracts.git", branch = "dev/vUST" }
+moneymarket-market = { path = "../market" }
+moneymarket-overseer = { path = "../overseer" }
+moneymarket-oracle = { path = "../oracle" }
+moneymarket-interest-model = { path = "../interest_model" }
+moneymarket-distribution-model = { path = "../distribution_model" }
+astroport = "0.3.1"
 
 [profile.dev]
 overflow-checks = true

--- a/contracts/overseer/schema/execute_msg.json
+++ b/contracts/overseer/schema/execute_msg.json
@@ -349,6 +349,26 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "repay_stable_from_yield_reserve"
+      ],
+      "properties": {
+        "repay_stable_from_yield_reserve": {
+          "type": "object",
+          "required": [
+            "borrower"
+          ],
+          "properties": {
+            "borrower": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/overseer/src/collateral.rs
+++ b/contracts/overseer/src/collateral.rs
@@ -16,7 +16,7 @@ use moneymarket::liquidation::LiquidationAmountResponse;
 use moneymarket::market::{BorrowerInfoResponse, ExecuteMsg as MarketExecuteMsg};
 use moneymarket::oracle::PriceResponse;
 use moneymarket::overseer::{AllCollateralsResponse, BorrowLimitResponse, CollateralsResponse};
-use moneymarket::querier::{deduct_tax, query_balance, query_price, TimeConstraints};
+use moneymarket::querier::{query_balance, query_price, TimeConstraints};
 use moneymarket::tokens::{Tokens, TokensHuman, TokensMath, TokensToHuman, TokensToRaw};
 
 pub fn lock_collateral(
@@ -228,13 +228,10 @@ pub fn repay_stable_from_yield_reserve(
     let repay_messages = vec![
         CosmosMsg::Bank(BankMsg::Send {
             to_address: market.to_string(),
-            amount: vec![deduct_tax(
-                deps.as_ref(),
-                Coin {
-                    denom: stable_denom,
-                    amount: borrow_amount.into(),
-                },
-            )?],
+            amount: vec![Coin {
+                denom: stable_denom,
+                amount: borrow_amount.into(),
+            }],
         }),
         CosmosMsg::Wasm(WasmMsg::Execute {
             contract_addr: market.to_string(),

--- a/contracts/overseer/src/collateral.rs
+++ b/contracts/overseer/src/collateral.rs
@@ -221,15 +221,17 @@ pub fn repay_stable_from_yield_reserve(
     )?;
     let borrow_amount = borrow_amount_res.loan_amount;
 
-    let prev_balance: Uint256 = query_balance(deps.as_ref(), market.clone(), config.stable_denom)?;
-
-    let stable_denom = String::from("uusd");
+    let prev_balance: Uint256 = query_balance(
+        deps.as_ref(),
+        market.clone(),
+        config.stable_denom.to_owned(),
+    )?;
 
     let repay_messages = vec![
         CosmosMsg::Bank(BankMsg::Send {
             to_address: market.to_string(),
             amount: vec![Coin {
-                denom: stable_denom,
+                denom: config.stable_denom,
                 amount: borrow_amount.into(),
             }],
         }),

--- a/contracts/overseer/src/contract.rs
+++ b/contracts/overseer/src/contract.rs
@@ -8,7 +8,7 @@ use std::cmp::{max, min};
 
 use crate::collateral::{
     liquidate_collateral, query_all_collaterals, query_borrow_limit, query_collaterals,
-    unlock_collateral,
+    repay_stable_from_yield_reserve, unlock_collateral,
 };
 use crate::error::ContractError;
 use crate::querier::query_epoch_state;
@@ -216,6 +216,10 @@ pub fn execute(
             liquidate_collateral(deps, env, info, api.addr_validate(&borrower)?)
         }
         ExecuteMsg::FundReserve {} => fund_reserve(deps, info),
+        ExecuteMsg::RepayStableFromYieldReserve { borrower } => {
+            let api = deps.api;
+            repay_stable_from_yield_reserve(deps, env, info, api.addr_validate(&borrower)?)
+        }
     }
 }
 

--- a/contracts/overseer/src/contract.rs
+++ b/contracts/overseer/src/contract.rs
@@ -92,37 +92,7 @@ pub fn instantiate(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> StdResult<Response> {
-    store_dynrate_config(
-        deps.storage,
-        &DynrateConfig {
-            dyn_rate_epoch: msg.dyn_rate_epoch,
-            dyn_rate_maxchange: msg.dyn_rate_maxchange,
-            dyn_rate_yr_increase_expectation: msg.dyn_rate_yr_increase_expectation,
-            dyn_rate_min: msg.dyn_rate_min,
-            dyn_rate_max: msg.dyn_rate_max,
-        },
-    )?;
-    let mut config = read_config(deps.storage)?;
-    let prev_yield_reserve = query_balance(
-        deps.as_ref(),
-        env.contract.address.clone(),
-        config.stable_denom.clone(),
-    )?;
-    store_dynrate_state(
-        deps.storage,
-        &DynrateState {
-            last_executed_height: env.block.height,
-            prev_yield_reserve: Decimal256::from_ratio(prev_yield_reserve, 1),
-        },
-    )?;
-    let new_rate = max(
-        min(config.threshold_deposit_rate, msg.dyn_rate_current),
-        msg.dyn_rate_min,
-    );
-    config.threshold_deposit_rate = new_rate;
-    config.target_deposit_rate = new_rate;
-    store_config(deps.storage, &config)?;
+pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
     Ok(Response::default())
 }
 

--- a/contracts/overseer/src/contract.rs
+++ b/contracts/overseer/src/contract.rs
@@ -7,8 +7,8 @@ use cosmwasm_std::{
 use std::cmp::{max, min};
 
 use crate::collateral::{
-    liquidate_collateral, lock_collateral, query_all_collaterals, query_borrow_limit,
-    query_collaterals, unlock_collateral,
+    liquidate_collateral, query_all_collaterals, query_borrow_limit, query_collaterals,
+    unlock_collateral,
 };
 use crate::error::ContractError;
 use crate::querier::query_epoch_state;
@@ -202,12 +202,12 @@ pub fn execute(
                 max_ltv,
             )
         }
-        ExecuteMsg::ExecuteEpochOperations {} => execute_epoch_operations(deps, env),
+        ExecuteMsg::ExecuteEpochOperations {} => Ok(Response::new()),
         ExecuteMsg::UpdateEpochState {
             interest_buffer,
             distributed_interest,
         } => update_epoch_state(deps, env, info, interest_buffer, distributed_interest),
-        ExecuteMsg::LockCollateral { collaterals } => lock_collateral(deps, info, collaterals),
+        ExecuteMsg::LockCollateral { collaterals: _ } => Ok(Response::new()),
         ExecuteMsg::UnlockCollateral { collaterals } => {
             unlock_collateral(deps, env, info, collaterals)
         }

--- a/contracts/overseer/src/contract.rs
+++ b/contracts/overseer/src/contract.rs
@@ -172,12 +172,12 @@ pub fn execute(
                 max_ltv,
             )
         }
-        ExecuteMsg::ExecuteEpochOperations {} => Ok(Response::new()),
+        ExecuteMsg::ExecuteEpochOperations {} => Err(ContractError::Deprecated {}),
         ExecuteMsg::UpdateEpochState {
             interest_buffer,
             distributed_interest,
         } => update_epoch_state(deps, env, info, interest_buffer, distributed_interest),
-        ExecuteMsg::LockCollateral { collaterals: _ } => Ok(Response::new()),
+        ExecuteMsg::LockCollateral { collaterals: _ } => Err(ContractError::Deprecated {}),
         ExecuteMsg::UnlockCollateral { collaterals } => {
             unlock_collateral(deps, env, info, collaterals)
         }

--- a/contracts/overseer/src/error.rs
+++ b/contracts/overseer/src/error.rs
@@ -26,4 +26,7 @@ pub enum ContractError {
 
     #[error("Unlock amount too high; Loan liability becomes greater than borrow limit: {0}")]
     UnlockTooLarge(u128),
+
+    #[error("Functionality deprecated")]
+    Deprecated {},
 }

--- a/contracts/overseer/src/testing/integration.rs
+++ b/contracts/overseer/src/testing/integration.rs
@@ -438,15 +438,6 @@ fn test_successfully_repay_stable_from_yield_reserve() {
 
     migrate_contracts(&mut app, &market_addr, &overseer_addr);
 
-    // borrow stable is not working now
-    let msg = MarketExecuteMsg::BorrowStable {
-        borrow_amount: Uint256::from(847_426_363_233u64),
-        to: None,
-    };
-
-    app.execute_contract(user.clone(), market_addr.clone(), &msg, &[])
-        .unwrap();
-
     // repay stable from yield reserve
     let msg = OverseerExecuteMsg::RepayStableFromYieldReserve {
         borrower: user.to_string(),

--- a/contracts/overseer/src/testing/integration.rs
+++ b/contracts/overseer/src/testing/integration.rs
@@ -1,0 +1,471 @@
+use astroport::token::InstantiateMsg as TokenInstantiateMsg;
+use cosmwasm_bignumber::{Decimal256, Uint256};
+use cosmwasm_std::testing::{mock_env, MockApi, MockStorage};
+use cosmwasm_std::{
+    coins, to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult,
+};
+use moneymarket::custody::{
+    BAssetInfo, ExecuteMsg as CustodyExecuteMsg, InstantiateMsg as CustodyInstantiateMsg,
+    QueryMsg as CustodyQueryMsg,
+};
+use moneymarket::distribution_model::InstantiateMsg as DistributionModelInstantiateMsg;
+use moneymarket::interest_model::InstantiateMsg as InterestModelInstantiateMsg;
+use moneymarket::market::{
+    BorrowerInfoResponse, ExecuteMsg as MarketExecuteMsg, InstantiateMsg as MarketInstantiateMsg,
+    MigrateMsg as MarketMigrateMsg, QueryMsg as MarketQueryMsg,
+};
+use moneymarket::oracle::{ExecuteMsg as OracleExecuteMsg, InstantiateMsg as OracleInstantiateMsg};
+use moneymarket::overseer::{
+    ExecuteMsg as OverseerExecuteMsg, InstantiateMsg as OverseerInstantiateMsg,
+    MigrateMsg as OverseerMigrateMsg,
+};
+use std::str::FromStr;
+use terra_multi_test::{AppBuilder, BankKeeper, ContractWrapper, Executor, TerraApp, TerraMock};
+
+const OWNER: &str = "owner";
+const USER: &str = "user";
+const ADMIN: &str = "admin";
+
+fn mock_app() -> TerraApp {
+    let env = mock_env();
+    let api = MockApi::default();
+    let bank = BankKeeper::new();
+    let storage = MockStorage::new();
+    let custom = TerraMock::luna_ust_case();
+
+    AppBuilder::new()
+        .with_api(api)
+        .with_block(env.block)
+        .with_bank(bank)
+        .with_storage(storage)
+        .with_custom(custom)
+        .build()
+}
+
+fn mock_custody_instantiate(
+    _deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    _msg: CustodyInstantiateMsg,
+) -> StdResult<Response> {
+    Ok(Response::default())
+}
+
+fn mock_custody_execute(
+    _deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    _msg: CustodyExecuteMsg,
+) -> Result<Response, StdError> {
+    Ok(Response::default())
+}
+
+fn mock_custody_query(_deps: Deps, _env: Env, _msg: CustodyQueryMsg) -> StdResult<Binary> {
+    to_binary(&())
+}
+
+fn store_token_contract_code(app: &mut TerraApp) -> u64 {
+    let token_contracct = Box::new(ContractWrapper::new_with_empty(
+        cw20_base::contract::execute,
+        cw20_base::contract::instantiate,
+        cw20_base::contract::query,
+    ));
+
+    app.store_code(token_contracct)
+}
+
+fn store_custody_contract_code(app: &mut TerraApp) -> u64 {
+    let custody_contract = Box::new(ContractWrapper::new_with_empty(
+        mock_custody_execute,
+        mock_custody_instantiate,
+        mock_custody_query,
+    ));
+    app.store_code(custody_contract)
+}
+
+fn store_market_contract_code_old(app: &mut TerraApp) -> u64 {
+    let market_contract = Box::new(
+        ContractWrapper::new_with_empty(
+            moneymarket_market_old::contract::execute,
+            moneymarket_market_old::contract::instantiate,
+            moneymarket_market_old::contract::query,
+        )
+        .with_reply_empty(moneymarket_market_old::contract::reply),
+    );
+
+    app.store_code(market_contract)
+}
+
+fn store_market_contract_code(app: &mut TerraApp) -> u64 {
+    let market_contract = Box::new(
+        ContractWrapper::new_with_empty(
+            moneymarket_market::contract::execute,
+            moneymarket_market::contract::instantiate,
+            moneymarket_market::contract::query,
+        )
+        .with_reply_empty(moneymarket_market::contract::reply)
+        .with_migrate_empty(moneymarket_market::contract::migrate),
+    );
+
+    app.store_code(market_contract)
+}
+
+fn store_overseer_contract_code_old(app: &mut TerraApp) -> u64 {
+    let overseer_contract = Box::new(ContractWrapper::new_with_empty(
+        moneymarket_overseer_old::contract::execute,
+        moneymarket_overseer_old::contract::instantiate,
+        moneymarket_overseer_old::contract::query,
+    ));
+
+    app.store_code(overseer_contract)
+}
+
+fn store_overseer_contract_code(app: &mut TerraApp) -> u64 {
+    let overseer_contract = Box::new(
+        ContractWrapper::new_with_empty(
+            moneymarket_overseer::contract::execute,
+            moneymarket_overseer::contract::instantiate,
+            moneymarket_overseer::contract::query,
+        )
+        .with_migrate_empty(moneymarket_overseer::contract::migrate),
+    );
+
+    app.store_code(overseer_contract)
+}
+
+fn store_oracle_contract_code(app: &mut TerraApp) -> u64 {
+    let oracle_contract = Box::new(ContractWrapper::new_with_empty(
+        moneymarket_oracle::contract::execute,
+        moneymarket_oracle::contract::instantiate,
+        moneymarket_oracle::contract::query,
+    ));
+
+    app.store_code(oracle_contract)
+}
+
+fn store_interest_model_code(app: &mut TerraApp) -> u64 {
+    let interest_model_contract = Box::new(ContractWrapper::new_with_empty(
+        moneymarket_interest_model::contract::execute,
+        moneymarket_interest_model::contract::instantiate,
+        moneymarket_interest_model::contract::query,
+    ));
+
+    app.store_code(interest_model_contract)
+}
+
+fn store_distribution_model_code(app: &mut TerraApp) -> u64 {
+    let distribution_model_contract = Box::new(ContractWrapper::new_with_empty(
+        moneymarket_distribution_model::contract::execute,
+        moneymarket_distribution_model::contract::instantiate,
+        moneymarket_distribution_model::contract::query,
+    ));
+
+    app.store_code(distribution_model_contract)
+}
+
+fn create_contracts() -> (TerraApp, Addr, Addr, Addr, Addr, Addr) {
+    let mut app = mock_app();
+    let owner = Addr::unchecked(OWNER);
+    let admin = Addr::unchecked(ADMIN);
+
+    app.init_bank_balance(&owner, coins(10000000, "uusd"))
+        .unwrap();
+
+    // these 3 contracts are not needed for now
+    let liquidator_addr = "liquidation_addr";
+    let collector_addr = "collector_addr";
+    let distributor_addr = "distributor_addr";
+    let reward_contract_addr = "reward_contract_addr";
+
+    // store contract codes
+    let token_code_id = store_token_contract_code(&mut app);
+    let custody_code_id = store_custody_contract_code(&mut app);
+    let oracle_code_id = store_oracle_contract_code(&mut app);
+    let interest_model_code_id = store_interest_model_code(&mut app);
+    let distribution_model_code_id = store_distribution_model_code(&mut app);
+    let market_code_id_old = store_market_contract_code_old(&mut app);
+    let overseer_code_id_old = store_overseer_contract_code_old(&mut app);
+
+    // instantiate oracle contract
+    let msg = OracleInstantiateMsg {
+        owner: owner.to_string(),
+        base_asset: "uusd".to_string(),
+    };
+    let oracle_addr = app
+        .instantiate_contract(
+            oracle_code_id,
+            owner.clone(),
+            &msg,
+            &[],
+            String::from("ORACLE"),
+            None,
+        )
+        .unwrap();
+
+    // instantiate interest model contract
+    let msg = InterestModelInstantiateMsg {
+        owner: owner.to_string(),
+        base_rate: Decimal256::percent(10),
+        interest_multiplier: Decimal256::percent(10),
+    };
+    let interest_model_addr = app
+        .instantiate_contract(
+            interest_model_code_id,
+            owner.clone(),
+            &msg,
+            &[],
+            String::from("INTEREST MODEL"),
+            None,
+        )
+        .unwrap();
+
+    // instantiate distribution model contract
+    let msg = DistributionModelInstantiateMsg {
+        owner: owner.to_string(),
+        emission_cap: Decimal256::from_uint256(100u64),
+        emission_floor: Decimal256::from_uint256(10u64),
+        increment_multiplier: Decimal256::percent(110),
+        decrement_multiplier: Decimal256::percent(90),
+    };
+    let distribution_model_addr = app
+        .instantiate_contract(
+            distribution_model_code_id,
+            owner.clone(),
+            &msg,
+            &[],
+            String::from("INTEREST MODEL"),
+            None,
+        )
+        .unwrap();
+
+    // instantitate market contract
+    let msg = MarketInstantiateMsg {
+        owner_addr: owner.to_string(),
+        stable_denom: "uusd".to_string(),
+        aterra_code_id: token_code_id,
+        anc_emission_rate: Decimal256::one(),
+        max_borrow_factor: Decimal256::one(),
+    };
+    let market_addr = app
+        .instantiate_contract(
+            market_code_id_old,
+            owner.clone(),
+            &msg,
+            &coins(1000000, "uusd"),
+            String::from("MARKET"),
+            Some(admin.to_string()),
+        )
+        .unwrap();
+
+    // instantiate overseer contract
+    let msg = OverseerInstantiateMsg {
+        owner_addr: owner.to_string(),
+        oracle_contract: oracle_addr.to_string(),
+        market_contract: market_addr.to_string(),
+        liquidation_contract: liquidator_addr.to_string(),
+        collector_contract: collector_addr.to_string(),
+        stable_denom: "uusd".to_string(),
+        epoch_period: 86400u64,
+        threshold_deposit_rate: Decimal256::permille(3),
+        target_deposit_rate: Decimal256::permille(5),
+        buffer_distribution_factor: Decimal256::percent(20),
+        anc_purchase_factor: Decimal256::percent(20),
+        price_timeframe: 60u64,
+        dyn_rate_epoch: 8600u64,
+        dyn_rate_maxchange: Decimal256::permille(5),
+        dyn_rate_yr_increase_expectation: Decimal256::permille(1),
+        dyn_rate_min: Decimal256::from_ratio(1000000000000u64, 1000000000000000000u64),
+        dyn_rate_max: Decimal256::from_ratio(1200000000000u64, 1000000000000000000u64),
+    };
+    let overseer_addr = app
+        .instantiate_contract(
+            overseer_code_id_old,
+            owner.clone(),
+            &msg,
+            &[],
+            String::from("OVERSEER"),
+            Some(admin.to_string()),
+        )
+        .unwrap();
+
+    // register contracts to market
+    let msg = MarketExecuteMsg::RegisterContracts {
+        overseer_contract: overseer_addr.to_string(),
+        interest_model: interest_model_addr.to_string(),
+        distribution_model: distribution_model_addr.to_string(),
+        collector_contract: collector_addr.to_string(),
+        distributor_contract: distributor_addr.to_string(),
+    };
+
+    app.execute_contract(owner.clone(), market_addr.clone(), &msg, &[])
+        .unwrap();
+
+    // instantiate bluna
+    let msg = TokenInstantiateMsg {
+        name: "bluna".to_string(),
+        symbol: "bluna".to_string(),
+        decimals: 6,
+        initial_balances: vec![],
+        mint: None,
+    };
+
+    let bluna_token_addr = app
+        .instantiate_contract(token_code_id, owner.clone(), &msg, &[], "bluna", None)
+        .unwrap();
+
+    // instantiate custody contract
+    let msg = CustodyInstantiateMsg {
+        owner: owner.to_string(),
+        collateral_token: bluna_token_addr.to_string(),
+        overseer_contract: overseer_addr.to_string(),
+        market_contract: market_addr.to_string(),
+        reward_contract: reward_contract_addr.to_string(),
+        liquidation_contract: liquidator_addr.to_string(),
+        stable_denom: "uusd".to_string(),
+        basset_info: BAssetInfo {
+            name: "bluna".to_string(),
+            symbol: "bluna".to_string(),
+            decimals: 6,
+        },
+    };
+
+    let custody_contract_addr = app
+        .instantiate_contract(
+            custody_code_id,
+            owner.clone(),
+            &msg,
+            &[],
+            String::from("CUSTODY"),
+            None,
+        )
+        .unwrap();
+
+    (
+        app,
+        market_addr,
+        overseer_addr,
+        bluna_token_addr,
+        custody_contract_addr,
+        oracle_addr,
+    )
+}
+
+fn migrate_contracts(app: &mut TerraApp, market_addr: &Addr, overseer_addr: &Addr) {
+    let admin = Addr::unchecked(ADMIN);
+
+    // store new contract code
+    let market_code_id = store_market_contract_code(app);
+    let overseer_code_id = store_overseer_contract_code(app);
+
+    // migrate market contract
+    let msg = MarketMigrateMsg {};
+    app.migrate_contract(admin.clone(), market_addr.clone(), &msg, market_code_id)
+        .unwrap();
+
+    // migrate overseer contract
+    let msg = OverseerMigrateMsg {};
+    app.migrate_contract(admin, overseer_addr.clone(), &msg, overseer_code_id)
+        .unwrap();
+}
+
+#[test]
+fn test_migration() {
+    let (mut app, market_addr, overseer_addr, _, _, _) = create_contracts();
+    migrate_contracts(&mut app, &market_addr, &overseer_addr);
+}
+
+#[test]
+fn test_successfully_repay_stable_from_yield_reserve() {
+    let owner = Addr::unchecked(OWNER);
+    let user = Addr::unchecked(USER);
+
+    let (mut app, market_addr, overseer_addr, bluna_token_addr, custody_contract_addr, oracle_addr) =
+        create_contracts();
+    app.init_bank_balance(&market_addr, coins(847_426_363u128, "uusd"))
+        .unwrap();
+    app.init_bank_balance(&overseer_addr, coins(1_000_000_000u128, "uusd"))
+        .unwrap();
+
+    // register whitelist
+    let msg = OverseerExecuteMsg::Whitelist {
+        name: "bluna".to_string(),
+        symbol: "bluna".to_string(),
+        collateral_token: bluna_token_addr.to_string(),
+        custody_contract: custody_contract_addr.to_string(),
+        max_ltv: Decimal256::percent(60),
+    };
+
+    app.execute_contract(owner.clone(), overseer_addr.clone(), &msg, &[])
+        .unwrap();
+
+    // lock some bluna
+    let msg = OverseerExecuteMsg::LockCollateral {
+        collaterals: vec![(
+            bluna_token_addr.to_string(),
+            Uint256::from(1_000_000_000u64),
+        )],
+    };
+
+    app.execute_contract(user.clone(), overseer_addr.clone(), &msg, &[])
+        .unwrap();
+
+    // feed bluna price
+    let msg = OracleExecuteMsg::RegisterFeeder {
+        asset: bluna_token_addr.to_string(),
+        feeder: owner.to_string(),
+    };
+
+    app.execute_contract(owner.clone(), oracle_addr.clone(), &msg, &[])
+        .unwrap();
+
+    let msg = OracleExecuteMsg::FeedPrice {
+        prices: vec![(
+            bluna_token_addr.to_string(),
+            Decimal256::from_str("10").unwrap(),
+        )],
+    };
+
+    app.execute_contract(owner, oracle_addr, &msg, &[]).unwrap();
+
+    // borrow UST agaist bluna
+    let msg = MarketExecuteMsg::BorrowStable {
+        borrow_amount: Uint256::from(847_426_363u64),
+        to: None,
+    };
+
+    app.execute_contract(user.clone(), market_addr.clone(), &msg, &[])
+        .unwrap();
+
+    migrate_contracts(&mut app, &market_addr, &overseer_addr);
+
+    // borrow stable is not working now
+    let msg = MarketExecuteMsg::BorrowStable {
+        borrow_amount: Uint256::from(847_426_363_233u64),
+        to: None,
+    };
+
+    app.execute_contract(user.clone(), market_addr.clone(), &msg, &[])
+        .unwrap();
+
+    // repay stable from yield reserve
+    let msg = OverseerExecuteMsg::RepayStableFromYieldReserve {
+        borrower: user.to_string(),
+    };
+
+    app.execute_contract(user.clone(), overseer_addr.clone(), &msg, &[])
+        .unwrap();
+
+    // check remain loan amount of the user
+    let res: BorrowerInfoResponse = app
+        .wrap()
+        .query_wasm_smart(
+            market_addr.clone(),
+            &MarketQueryMsg::BorrowerInfo {
+                borrower: user.to_string(),
+                block_height: None,
+            },
+        )
+        .unwrap();
+
+    assert_eq!(res.loan_amount, Uint256::zero());
+}

--- a/contracts/overseer/src/testing/mod.rs
+++ b/contracts/overseer/src/testing/mod.rs
@@ -1,3 +1,4 @@
 mod collateral_ut;
+mod integration;
 mod mock_querier;
 mod tests;

--- a/contracts/overseer/src/testing/tests.rs
+++ b/contracts/overseer/src/testing/tests.rs
@@ -1,3 +1,4 @@
+use crate::collateral::lock_collateral as _lock_collateral;
 use crate::contract::{execute, instantiate, query};
 use crate::error::ContractError;
 use crate::querier::query_epoch_state;
@@ -363,6 +364,7 @@ fn whitelist() {
 }
 
 #[test]
+#[ignore = "deprecated functionality"]
 fn execute_epoch_operations() {
     let mut deps = mock_dependencies(&[Coin {
         denom: "uusd".to_string(),
@@ -747,6 +749,7 @@ fn update_epoch_state() {
 }
 
 #[test]
+#[ignore = "deprecated functionality"]
 fn lock_collateral() {
     let mut deps = mock_dependencies(&[]);
 
@@ -954,14 +957,20 @@ fn unlock_collateral() {
 
     let _res = execute(deps.as_mut(), env.clone(), info, msg);
 
+    let collaterals = vec![
+        ("bluna".to_string(), Uint256::from(1000000u64)),
+        ("batom".to_string(), Uint256::from(10000000u64)),
+    ];
+
+    // lock collateral is no-ops
     let msg = ExecuteMsg::LockCollateral {
-        collaterals: vec![
-            ("bluna".to_string(), Uint256::from(1000000u64)),
-            ("batom".to_string(), Uint256::from(10000000u64)),
-        ],
+        collaterals: collaterals.clone(),
     };
     let info = mock_info("addr0000", &[]);
     let _res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+
+    // simulate lock collateral
+    _lock_collateral(deps.as_mut(), info.clone(), collaterals).unwrap();
 
     // Failed to unlock more than locked amount
     let msg = ExecuteMsg::UnlockCollateral {
@@ -1187,14 +1196,20 @@ fn liquidate_collateral() {
 
     let _res = execute(deps.as_mut(), env.clone(), info, msg);
 
+    let collaterals = vec![
+        (bluna_collat_token.clone(), Uint256::from(1000000u64)),
+        (batom_collat_token.clone(), Uint256::from(10000000u64)),
+    ];
+
+    // lock collateral is no-ops
     let msg = ExecuteMsg::LockCollateral {
-        collaterals: vec![
-            (bluna_collat_token.clone(), Uint256::from(1000000u64)),
-            (batom_collat_token.clone(), Uint256::from(10000000u64)),
-        ],
+        collaterals: collaterals.clone(),
     };
     let info = mock_info("addr0000", &[]);
-    let _res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+    let _res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+
+    // simulate lock collateral
+    _lock_collateral(deps.as_mut(), info, collaterals).unwrap();
 
     deps.querier.with_oracle_price(&[
         (

--- a/contracts/overseer/src/testing/tests.rs
+++ b/contracts/overseer/src/testing/tests.rs
@@ -962,12 +962,7 @@ fn unlock_collateral() {
         ("batom".to_string(), Uint256::from(10000000u64)),
     ];
 
-    // lock collateral is no-ops
-    let msg = ExecuteMsg::LockCollateral {
-        collaterals: collaterals.clone(),
-    };
     let info = mock_info("addr0000", &[]);
-    let _res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
 
     // simulate lock collateral
     _lock_collateral(deps.as_mut(), info.clone(), collaterals).unwrap();
@@ -1201,12 +1196,7 @@ fn liquidate_collateral() {
         (batom_collat_token.clone(), Uint256::from(10000000u64)),
     ];
 
-    // lock collateral is no-ops
-    let msg = ExecuteMsg::LockCollateral {
-        collaterals: collaterals.clone(),
-    };
     let info = mock_info("addr0000", &[]);
-    let _res = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
 
     // simulate lock collateral
     _lock_collateral(deps.as_mut(), info, collaterals).unwrap();

--- a/packages/moneymarket/src/overseer.rs
+++ b/packages/moneymarket/src/overseer.rs
@@ -131,8 +131,8 @@ pub enum ExecuteMsg {
     FundReserve {},
 
     RepayStableFromYieldReserve {
-        borrower: String
-    }
+        borrower: String,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/moneymarket/src/overseer.rs
+++ b/packages/moneymarket/src/overseer.rs
@@ -129,6 +129,10 @@ pub enum ExecuteMsg {
     },
 
     FundReserve {},
+
+    RepayStableFromYieldReserve {
+        borrower: String
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/moneymarket/src/overseer.rs
+++ b/packages/moneymarket/src/overseer.rs
@@ -48,17 +48,7 @@ pub struct InstantiateMsg {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {
-    /// Period of time in blocks when rate is evaluated/changed
-    pub dyn_rate_epoch: u64,
-    /// Maximum allowed rate change per epoch
-    pub dyn_rate_maxchange: Decimal256,
-    /// Margin to define expectation of rate increase
-    pub dyn_rate_yr_increase_expectation: Decimal256,
-    pub dyn_rate_current: Decimal256,
-    pub dyn_rate_min: Decimal256,
-    pub dyn_rate_max: Decimal256,
-}
+pub struct MigrateMsg {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
## Summary of changes

### Overseer:
- deprecates:  `ExecuteEpochOperations` and `LockCollateral`
- adds `RepayStableFromYieldReserve` which repays borrower's loan amount from yield reserve

### Market:
- deprecates: `ExecuteEpochOperations`, `LockCollateral`, `DepositStable`, `BorrowStable`, `ClaimRewards` and `RepayStable`

### Todos:

- [x] Add tests for `RepayStableFromYieldReserve`

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Added a relevant changelog entry to CHANGELOG.md

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
